### PR TITLE
v2.0: Hexagonal Architecture upgrade

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
           extensions: dom, curl, libxml, mbstring, zip
           coverage: none
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
           extensions: dom, curl, libxml, mbstring, zip
           coverage: none
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,14 +12,28 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4]
-        laravel: [12.*, 13.*]
+        php: [8.3, 8.4]
+        laravel: [12.*]
         stability: [prefer-stable]
         include:
           - laravel: 12.*
             testbench: 10.*
-          - laravel: 13.*
+            pest: 3
+          - php: 8.3
+            laravel: 13.*
             testbench: 11.*
+            pest: 4
+            stability: prefer-stable
+          - php: 8.4
+            laravel: 13.*
+            testbench: 11.*
+            pest: 4
+            stability: prefer-stable
+          - php: 8.5
+            laravel: 13.*
+            testbench: 11.*
+            pest: 4
+            stability: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
@@ -40,7 +54,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --dev --no-interaction --no-update
+          if [ "${{ matrix.pest }}" = "4" ]; then
+            composer require "pestphp/pest:^4.0" "pestphp/pest-plugin-laravel:^4.0" --dev --no-interaction --no-update
+          fi
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests (PEST)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3, 8.4]
-        laravel: [12.*]
+        php: [8.4]
+        laravel: [12.*, 13.*]
         stability: [prefer-stable]
         include:
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ composer.lock
 # Generated files
 generated/
 
+# Internal Notes
+/private/*
+
 # IDE
 .vscode/
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ generated/
 *.swo
 *~
 
+# Worktrees
+.worktrees/
+
 # Testing
 coverage/
 .phpunit.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to `laravel-clean-architecture` will be documented in this file.
 
+## [2.0.0] - 2026-03-31
+
+### Breaking Changes
+
+- Domain models now live under `Domain/{Name}/Models/` instead of directly under `Domain/{Name}/`
+- Domain enums now live under `Domain/{Name}/Enums/` and domain events under `Domain/{Name}/Events/` (nested subdirectory structure is now enforced)
+- Infrastructure HTTP files are now consolidated under `Infrastructure/Http/` (previously `Infrastructure/API/`)
+- PHP 8.4+ is now required (previously 8.3+)
+
+### Added
+
+- Laravel 13 support alongside Laravel 12
+- Interactive prompts in `make-domain` for optional components (Observer, Listener, Job, Mail, Notification, Export)
+- `clean-arch:make-observer {name} {domain}` command to generate domain observers
+- `clean-arch:make-listener {name}` command to generate event listeners
+- `clean-arch:make-job {name}` command to generate queued jobs
+- `clean-arch:make-mail {name}` command to generate mailables
+- `clean-arch:make-notification {name}` command to generate notifications
+- `clean-arch:make-export {name}` command to generate exports
+- `clean-arch:validate` command for architectural dependency validation (CI-friendly, returns exit code 1 on violations)
+
+### Changed
+
+- `clean-arch:generate-package` updated to reflect v2 nested directory structure
+
 ## [Unreleased]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ All notable changes to `laravel-clean-architecture` will be documented in this f
 - Domain models now live under `Domain/{Name}/Models/` instead of directly under `Domain/{Name}/`
 - Domain enums now live under `Domain/{Name}/Enums/` and domain events under `Domain/{Name}/Events/` (nested subdirectory structure is now enforced)
 - Infrastructure HTTP files are now consolidated under `Infrastructure/Http/` (previously `Infrastructure/API/`)
-- PHP 8.4+ is now required (previously 8.3+)
+- PHP 8.3+ is now the minimum (previously 8.3 only)
 
 ### Added
 
 - Laravel 13 support alongside Laravel 12
+
 - Interactive prompts in `make-domain` for optional components (Observer, Listener, Job, Mail, Notification, Export)
 - `clean-arch:make-observer {name} {domain}` command to generate domain observers
 - `clean-arch:make-listener {name}` command to generate event listeners

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ A Laravel package to easily implement Clean Architecture in your projects. 🚀
 
 ## 📋 Requirements
 
-- 🐘 PHP 8.4+
-- ⚡ Laravel 12.x or 13.x
+- 🐘 PHP 8.3+
+- ⚡ Laravel 12.x / 13.x
 
 ## 📦 Installation
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ A Laravel package to easily implement Clean Architecture in your projects. 🚀
 - 🔧 **Customizable** - Flexible configuration to fit your project needs
 - 🧪 **Test-Ready** - Pre-built test templates for immediate testing
 - 📚 **Well-Documented** - Comprehensive documentation and examples
-- 🎨 **Modern PHP** - Built for PHP 8.3+ with latest Laravel features
+- 🎨 **Modern PHP** - Built for PHP 8.4+ with latest Laravel features
 
 ## 📋 Requirements
 
-- 🐘 PHP 8.3+
-- ⚡ Laravel 12.x
+- 🐘 PHP 8.4+
+- ⚡ Laravel 12.x or 13.x
 
 ## 📦 Installation
 
@@ -69,6 +69,16 @@ This command will generate:
 - 📤 API Resource
 - 🧪 Feature tests
 
+After generating the core files, `make-domain` prompts interactively for optional components. You can choose to also generate an Observer, Listener, Job, Mail, Notification, and Export for the domain. Each prompt can be answered independently, so you only generate what your domain needs.
+
+### ✅ Architecture validation
+
+```bash
+php artisan clean-arch:validate
+```
+
+This command checks your codebase for layer dependency violations (for example, Domain code importing from Infrastructure). It returns exit code 1 when violations are found, making it suitable for use in CI pipelines.
+
 ### 🛠️ Available commands
 
 - `clean-arch:install` - 🏗️ Install Clean Architecture structure
@@ -76,6 +86,13 @@ This command will generate:
 - `clean-arch:make-action {name} {domain}` - ⚡ Create a new action
 - `clean-arch:make-service {name}` - 🔧 Create a new service
 - `clean-arch:make-controller {name}` - 🌐 Create a new controller
+- `clean-arch:make-observer {name} {domain}` - 👁️ Create a new observer
+- `clean-arch:make-listener {name}` - 👂 Create a new listener
+- `clean-arch:make-job {name}` - ⏳ Create a new job
+- `clean-arch:make-mail {name}` - 📧 Create a new mailable
+- `clean-arch:make-notification {name}` - 🔔 Create a new notification
+- `clean-arch:make-export {name}` - 📤 Create a new export
+- `clean-arch:validate` - ✅ Validate architecture dependency rules
 - `clean-arch:generate-package {name} {vendor}` - 📦 Generate a new package
 
 ### 📂 Generated structure
@@ -93,17 +110,19 @@ app/
 │       └── UserService.php
 ├── Domain/
 │   └── Users/
-│       ├── User.php
+│       ├── Models/
+│       │   └── User.php
 │       ├── Enums/
-│   │   └── UserStatus.php
-│   └── Events/
-│       ├── UserCreated.php
-│       ├── UserUpdated.php
-│       └── UserDeleted.php
+│       │   └── UserStatus.php
+│       └── Events/
+│           ├── UserCreated.php
+│           ├── UserUpdated.php
+│           └── UserDeleted.php
 └── Infrastructure/
-    └── API/
+    └── Http/
         ├── Controllers/
-        │   └── UsersController.php
+        │   └── Api/
+        │       └── UsersController.php
         ├── Requests/
         │   ├── CreateUserRequest.php
         │   └── UpdateUserRequest.php

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Laravel package for generating Clean Architecture structure",
     "type": "library",
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "illuminate/console": "^12.0 || ^13.0",
         "illuminate/support": "^12.0 || ^13.0",
         "illuminate/filesystem": "^12.0 || ^13.0"
@@ -11,9 +11,9 @@
     "require-dev": {
         "laravel/pint": "^1.13",
         "orchestra/testbench": "^10.0 || ^11.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
-        "larastan/larastan": "^3.4.0",
+        "pestphp/pest": "^3.0 || ^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0 || ^4.0",
+        "larastan/larastan": "^3.9",
         "mockery/mockery": "^1.6"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,14 @@
     "description": "Laravel package for generating Clean Architecture structure",
     "type": "library",
     "require": {
-        "php": "^8.3",
-        "illuminate/console": "^12.0",
-        "illuminate/support": "^12.0",
-        "illuminate/filesystem": "^12.0"
+        "php": "^8.4",
+        "illuminate/console": "^12.0 || ^13.0",
+        "illuminate/support": "^12.0 || ^13.0",
+        "illuminate/filesystem": "^12.0 || ^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.13",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0",
         "larastan/larastan": "^3.4.0",

--- a/config/clean-architecture.php
+++ b/config/clean-architecture.php
@@ -28,6 +28,8 @@ return [
         'paths'   => [
             'app/Application/Actions',
             'app/Application/Services',
+            'app/Application/Jobs',
+            'app/Application/Listeners',
             'app/Domain',
         ],
     ],

--- a/src/CleanArchitectureServiceProvider.php
+++ b/src/CleanArchitectureServiceProvider.php
@@ -8,7 +8,14 @@ use PlinCode\LaravelCleanArchitecture\Commands\InstallCleanArchitectureCommand;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeActionCommand;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeControllerCommand;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeDomainCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeExportCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeJobCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeListenerCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeMailCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeNotificationCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeObserverCommand;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeServiceCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\ValidateArchitectureCommand;
 
 class CleanArchitectureServiceProvider extends ServiceProvider
 {
@@ -21,6 +28,13 @@ class CleanArchitectureServiceProvider extends ServiceProvider
                 MakeActionCommand::class,
                 MakeServiceCommand::class,
                 MakeControllerCommand::class,
+                MakeObserverCommand::class,
+                MakeListenerCommand::class,
+                MakeJobCommand::class,
+                MakeMailCommand::class,
+                MakeNotificationCommand::class,
+                MakeExportCommand::class,
+                ValidateArchitectureCommand::class,
                 GeneratePackageCommand::class,
             ]);
         }

--- a/src/Commands/GeneratePackageCommand.php
+++ b/src/Commands/GeneratePackageCommand.php
@@ -54,6 +54,10 @@ class GeneratePackageCommand extends Command
         $directories = [
             'src',
             'src/Commands',
+            'src/Domain',
+            'src/Application/Actions',
+            'src/Application/Services',
+            'src/Infrastructure/Http/Controllers',
             'stubs',
             'config',
             'tests',
@@ -91,10 +95,10 @@ class GeneratePackageCommand extends Command
                 ],
             ],
             'require' => [
-                'php'                   => '^8.3',
-                'illuminate/support'    => '^11.0|^12.0',
-                'illuminate/console'    => '^11.0|^12.0',
-                'illuminate/filesystem' => '^11.0|^12.0',
+                'php'                   => '^8.4',
+                'illuminate/support'    => '^12.0|^13.0',
+                'illuminate/console'    => '^12.0|^13.0',
+                'illuminate/filesystem' => '^12.0|^13.0',
             ],
             'autoload' => [
                 'psr-4' => [

--- a/src/Commands/GeneratePackageCommand.php
+++ b/src/Commands/GeneratePackageCommand.php
@@ -95,7 +95,7 @@ class GeneratePackageCommand extends Command
                 ],
             ],
             'require' => [
-                'php'                   => '^8.4',
+                'php'                   => '^8.3',
                 'illuminate/support'    => '^12.0|^13.0',
                 'illuminate/console'    => '^12.0|^13.0',
                 'illuminate/filesystem' => '^12.0|^13.0',

--- a/src/Commands/InstallCleanArchitectureCommand.php
+++ b/src/Commands/InstallCleanArchitectureCommand.php
@@ -52,22 +52,23 @@ class InstallCleanArchitectureCommand extends Command
     protected function createDirectoryStructure(): void
     {
         $directories = [
+            'app/Domain',
             'app/Application/Actions',
             'app/Application/Services',
             'app/Application/Jobs',
-            'app/Application/Console/Commands',
             'app/Application/Listeners',
-            'app/Domain',
-            'app/Infrastructure/API/Controllers',
-            'app/Infrastructure/API/Requests',
-            'app/Infrastructure/API/Resources',
-            'app/Infrastructure/UI/Web/Controllers',
-            'app/Infrastructure/UI/Web/Views',
+            'app/Application/Console/Commands',
+            'app/Infrastructure/Http/Controllers/Api',
+            'app/Infrastructure/Http/Middleware',
+            'app/Infrastructure/Http/Requests',
+            'app/Infrastructure/Http/Resources',
+            'app/Infrastructure/UI',
             'app/Infrastructure/Mail',
             'app/Infrastructure/Notifications',
             'app/Infrastructure/Observers',
+            'app/Infrastructure/Exports',
+            'app/Infrastructure/Validation',
             'app/Infrastructure/Exceptions',
-            'app/Infrastructure/Middleware',
         ];
 
         foreach ($directories as $directory) {
@@ -104,11 +105,14 @@ class InstallCleanArchitectureCommand extends Command
     protected function createBaseController(): void
     {
         $stub = $this->getStub('base-controller');
+        if (! $this->files->isDirectory(app_path('Infrastructure/Http/Controllers'))) {
+            $this->files->makeDirectory(app_path('Infrastructure/Http/Controllers'), 0755, true);
+        }
         $this->files->put(
-            app_path('Infrastructure/API/Controllers/Controller.php'),
+            app_path('Infrastructure/Http/Controllers/Controller.php'),
             $stub
         );
-        $this->info('Created: Infrastructure/API/Controllers/Controller.php');
+        $this->info('Created: Infrastructure/Http/Controllers/Controller.php');
     }
 
     protected function createBaseAction(): void
@@ -137,11 +141,14 @@ class InstallCleanArchitectureCommand extends Command
     protected function createBaseRequest(): void
     {
         $stub = $this->getStub('base-request');
+        if (! $this->files->isDirectory(app_path('Infrastructure/Http/Requests'))) {
+            $this->files->makeDirectory(app_path('Infrastructure/Http/Requests'), 0755, true);
+        }
         $this->files->put(
-            app_path('Infrastructure/API/Requests/BaseRequest.php'),
+            app_path('Infrastructure/Http/Requests/BaseRequest.php'),
             $stub
         );
-        $this->info('Created: Infrastructure/API/Requests/BaseRequest.php');
+        $this->info('Created: Infrastructure/Http/Requests/BaseRequest.php');
     }
 
     protected function createExceptionClasses(): void

--- a/src/Commands/MakeControllerCommand.php
+++ b/src/Commands/MakeControllerCommand.php
@@ -54,13 +54,13 @@ class MakeControllerCommand extends Command
         $stub    = $this->getStub('controller');
         $content = $this->replacePlaceholders($stub, $name);
 
-        $controllersPath = app_path('Infrastructure/API/Controllers');
+        $controllersPath = app_path('Infrastructure/Http/Controllers/Api');
         if (! $this->files->isDirectory($controllersPath)) {
             $this->files->makeDirectory($controllersPath, 0755, true);
         }
 
         $this->files->put("{$controllersPath}/{$name}Controller.php", $content);
-        $this->info("Created: Infrastructure/API/Controllers/{$name}Controller.php");
+        $this->info("Created: Infrastructure/Http/Controllers/Api/{$name}Controller.php");
     }
 
     protected function createWebController(string $name): void

--- a/src/Commands/MakeDomainCommand.php
+++ b/src/Commands/MakeDomainCommand.php
@@ -26,9 +26,8 @@ class MakeDomainCommand extends Command
         $name  = $this->argument('name');
         $force = $this->option('force');
 
-        $this->info("🚀 Creating domain: {$name}");
+        $this->info("Creating domain: {$name}");
 
-        // Create domain structure
         $this->createDomainModel($name);
         $this->createDomainEnums($name);
         $this->createDomainEvents($name);
@@ -38,18 +37,30 @@ class MakeDomainCommand extends Command
         $this->createRequests($name);
         $this->createResource($name);
         $this->createTests($name);
-
-        // Create migration
         $this->createMigration($name);
 
-        // Add .gitkeep to empty directories
+        if ($this->confirm('Would you like to generate an Observer?', false)) {
+            $this->createObserver($name);
+        }
+        if ($this->confirm('Would you like to generate a Listener?', false)) {
+            $this->createListener($name);
+        }
+        if ($this->confirm('Would you like to generate a Job?', false)) {
+            $this->createJob($name);
+        }
+        if ($this->confirm('Would you like to generate a Mail?', false)) {
+            $this->createMail($name);
+        }
+        if ($this->confirm('Would you like to generate a Notification?', false)) {
+            $this->createNotification($name);
+        }
+        if ($this->confirm('Would you like to generate an Export?', false)) {
+            $this->createExport($name);
+        }
+
         $this->addGitKeepFiles($name);
 
-        $this->info("✅ Domain {$name} created successfully!");
-        $this->newLine();
-        $this->info('Next steps:');
-        $this->info('1. Add routes to routes/api.php');
-        $this->info('2. Run tests: php artisan test');
+        $this->info("Domain {$name} created successfully!");
 
         return self::SUCCESS;
     }
@@ -60,14 +71,14 @@ class MakeDomainCommand extends Command
         $content = $this->replacePlaceholders($stub, $name);
 
         $pluralName = Str::plural($name);
-        $path       = app_path("Domain/{$pluralName}/{$name}.php");
+        $path       = app_path("Domain/{$pluralName}/Models/{$name}.php");
 
         if (! $this->files->isDirectory(dirname($path))) {
             $this->files->makeDirectory(dirname($path), 0755, true);
         }
 
         $this->files->put($path, $content);
-        $this->info("Created: Domain/{$pluralName}/{$name}.php");
+        $this->info("Created: Domain/{$pluralName}/Models/{$name}.php");
     }
 
     protected function createDomainEnums(string $name): void
@@ -155,16 +166,24 @@ class MakeDomainCommand extends Command
         $content = $this->replacePlaceholders($stub, $name);
 
         $pluralName      = Str::plural($name);
-        $controllersPath = app_path('Infrastructure/API/Controllers');
+        $controllersPath = app_path('Infrastructure/Http/Controllers/Api');
+
+        if (! $this->files->isDirectory($controllersPath)) {
+            $this->files->makeDirectory($controllersPath, 0755, true);
+        }
 
         $this->files->put("{$controllersPath}/{$pluralName}Controller.php", $content);
-        $this->info("Created: Infrastructure/API/Controllers/{$pluralName}Controller.php");
+        $this->info("Created: Infrastructure/Http/Controllers/Api/{$pluralName}Controller.php");
     }
 
     protected function createRequests(string $name): void
     {
         $requests     = ['Create', 'Update'];
-        $requestsPath = app_path('Infrastructure/API/Requests');
+        $requestsPath = app_path('Infrastructure/Http/Requests');
+
+        if (! $this->files->isDirectory($requestsPath)) {
+            $this->files->makeDirectory($requestsPath, 0755, true);
+        }
 
         foreach ($requests as $request) {
             $stub    = $this->getStub('request');
@@ -173,7 +192,7 @@ class MakeDomainCommand extends Command
             ]);
 
             $this->files->put("{$requestsPath}/{$request}{$name}Request.php", $content);
-            $this->info("Created: Infrastructure/API/Requests/{$request}{$name}Request.php");
+            $this->info("Created: Infrastructure/Http/Requests/{$request}{$name}Request.php");
         }
     }
 
@@ -182,18 +201,20 @@ class MakeDomainCommand extends Command
         $stub    = $this->getStub('resource');
         $content = $this->replacePlaceholders($stub, $name);
 
-        $resourcesPath = app_path('Infrastructure/API/Resources');
+        $resourcesPath = app_path('Infrastructure/Http/Resources');
         if (! $this->files->isDirectory($resourcesPath)) {
             $this->files->makeDirectory($resourcesPath, 0755, true);
         }
 
         $this->files->put("{$resourcesPath}/{$name}Resource.php", $content);
-        $this->info("Created: Infrastructure/API/Resources/{$name}Resource.php");
+        $this->info("Created: Infrastructure/Http/Resources/{$name}Resource.php");
     }
 
     protected function createTests(string $name): void
     {
-        $testsPath = base_path('tests/Feature');
+        $pluralName = Str::plural($name);
+        $testsPath  = base_path("tests/Feature/{$pluralName}");
+
         if (! $this->files->isDirectory($testsPath)) {
             $this->files->makeDirectory($testsPath, 0755, true);
         }
@@ -201,9 +222,8 @@ class MakeDomainCommand extends Command
         $stub    = $this->getStub('test');
         $content = $this->replacePlaceholders($stub, $name);
 
-        $pluralName = Str::plural($name);
-        $this->files->put("{$testsPath}/{$pluralName}Test.php", $content);
-        $this->info("Created: tests/Feature/{$pluralName}Test.php");
+        $this->files->put("{$testsPath}/{$name}Test.php", $content);
+        $this->info("Created: tests/Feature/{$pluralName}/{$name}Test.php");
     }
 
     protected function createMigration(string $name): void
@@ -220,20 +240,110 @@ class MakeDomainCommand extends Command
     {
         $pluralName  = Str::plural($name);
         $directories = [
-            app_path("Domain/{$pluralName}"),
+            app_path("Domain/{$pluralName}/Models"),
             app_path("Domain/{$pluralName}/Enums"),
             app_path("Domain/{$pluralName}/Events"),
             app_path("Application/Actions/{$pluralName}"),
-            app_path('Infrastructure/API/Requests'),
-            app_path('Infrastructure/API/Resources'),
+            app_path('Infrastructure/Http/Requests'),
+            app_path('Infrastructure/Http/Resources'),
         ];
 
         foreach ($directories as $directory) {
             if ($this->files->isDirectory($directory) && count($this->files->files($directory)) === 0) {
                 $this->files->put("{$directory}/.gitkeep", '');
-                $this->info("Added .gitkeep to: {$directory}");
             }
         }
+    }
+
+    protected function createObserver(string $name): void
+    {
+        $stub    = $this->getStub('observer');
+        $content = $this->replacePlaceholders($stub, $name);
+
+        $pluralName   = Str::plural($name);
+        $observerPath = app_path("Infrastructure/Observers/{$pluralName}");
+
+        if (! $this->files->isDirectory($observerPath)) {
+            $this->files->makeDirectory($observerPath, 0755, true);
+        }
+
+        $this->files->put("{$observerPath}/{$name}Observer.php", $content);
+        $this->info("Created: Infrastructure/Observers/{$pluralName}/{$name}Observer.php");
+    }
+
+    protected function createListener(string $name): void
+    {
+        $stub    = $this->getStub('listener');
+        $content = $this->replacePlaceholders($stub, $name);
+
+        $listenerPath = app_path('Application/Listeners');
+
+        if (! $this->files->isDirectory($listenerPath)) {
+            $this->files->makeDirectory($listenerPath, 0755, true);
+        }
+
+        $this->files->put("{$listenerPath}/{$name}EventListener.php", $content);
+        $this->info("Created: Application/Listeners/{$name}EventListener.php");
+    }
+
+    protected function createJob(string $name): void
+    {
+        $stub    = $this->getStub('job');
+        $content = $this->replacePlaceholders($stub, $name);
+
+        $jobsPath = app_path('Application/Jobs');
+
+        if (! $this->files->isDirectory($jobsPath)) {
+            $this->files->makeDirectory($jobsPath, 0755, true);
+        }
+
+        $this->files->put("{$jobsPath}/Process{$name}Job.php", $content);
+        $this->info("Created: Application/Jobs/Process{$name}Job.php");
+    }
+
+    protected function createMail(string $name): void
+    {
+        $stub    = $this->getStub('mail');
+        $content = $this->replacePlaceholders($stub, $name);
+
+        $mailPath = app_path('Infrastructure/Mail');
+
+        if (! $this->files->isDirectory($mailPath)) {
+            $this->files->makeDirectory($mailPath, 0755, true);
+        }
+
+        $this->files->put("{$mailPath}/{$name}Mail.php", $content);
+        $this->info("Created: Infrastructure/Mail/{$name}Mail.php");
+    }
+
+    protected function createNotification(string $name): void
+    {
+        $stub    = $this->getStub('notification');
+        $content = $this->replacePlaceholders($stub, $name);
+
+        $notificationsPath = app_path('Infrastructure/Notifications');
+
+        if (! $this->files->isDirectory($notificationsPath)) {
+            $this->files->makeDirectory($notificationsPath, 0755, true);
+        }
+
+        $this->files->put("{$notificationsPath}/{$name}Notification.php", $content);
+        $this->info("Created: Infrastructure/Notifications/{$name}Notification.php");
+    }
+
+    protected function createExport(string $name): void
+    {
+        $stub    = $this->getStub('export');
+        $content = $this->replacePlaceholders($stub, $name);
+
+        $exportsPath = app_path('Infrastructure/Exports');
+
+        if (! $this->files->isDirectory($exportsPath)) {
+            $this->files->makeDirectory($exportsPath, 0755, true);
+        }
+
+        $this->files->put("{$exportsPath}/{$name}Export.php", $content);
+        $this->info("Created: Infrastructure/Exports/{$name}Export.php");
     }
 
     protected function replacePlaceholders(string $content, string $name, array $extra = []): string

--- a/src/Commands/MakeExportCommand.php
+++ b/src/Commands/MakeExportCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace PlinCode\LaravelCleanArchitecture\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+class MakeExportCommand extends Command
+{
+    protected $signature = 'clean-arch:make-export {name : The name of the export}
+                          {--force : Overwrite existing files}';
+
+    protected $description = 'Create a new export in the Infrastructure layer';
+
+    protected Filesystem $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+        $this->files = $files;
+    }
+
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+
+        $this->info("Creating export: {$name}");
+        $this->createExport($name);
+        $this->info("Export {$name} created successfully!");
+
+        return self::SUCCESS;
+    }
+
+    protected function createExport(string $name): void
+    {
+        $stub    = $this->getStub('export');
+        $content = $this->replacePlaceholders($stub, $name);
+
+        $exportPath = app_path('Infrastructure/Exports');
+
+        if (! $this->files->isDirectory($exportPath)) {
+            $this->files->makeDirectory($exportPath, 0755, true);
+        }
+
+        $this->files->put("{$exportPath}/{$name}Export.php", $content);
+        $this->info("Created: Infrastructure/Exports/{$name}Export.php");
+    }
+
+    protected function replacePlaceholders(string $content, string $name): string
+    {
+        $pluralName     = Str::plural($name);
+        $domainVariable = Str::camel($name);
+
+        return str_replace(
+            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
+            [$name, $pluralName, $domainVariable],
+            $content
+        );
+    }
+
+    protected function getStub(string $stub): string
+    {
+        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
+
+        if (! $this->files->exists($stubPath)) {
+            throw new \Exception("Stub file not found: {$stubPath}");
+        }
+
+        return $this->files->get($stubPath);
+    }
+}

--- a/src/Commands/MakeJobCommand.php
+++ b/src/Commands/MakeJobCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace PlinCode\LaravelCleanArchitecture\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+class MakeJobCommand extends Command
+{
+    protected $signature = 'clean-arch:make-job {name : The name of the job}
+                          {--force : Overwrite existing files}';
+
+    protected $description = 'Create a new job in the Application layer';
+
+    protected Filesystem $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+        $this->files = $files;
+    }
+
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+
+        $this->info("Creating job: {$name}");
+        $this->createJob($name);
+        $this->info("Job {$name} created successfully!");
+
+        return self::SUCCESS;
+    }
+
+    protected function createJob(string $name): void
+    {
+        $stub    = $this->getStub('job');
+        $content = $this->replacePlaceholders($stub, $name);
+
+        $jobPath = app_path('Application/Jobs');
+
+        if (! $this->files->isDirectory($jobPath)) {
+            $this->files->makeDirectory($jobPath, 0755, true);
+        }
+
+        $this->files->put("{$jobPath}/{$name}Job.php", $content);
+        $this->info("Created: Application/Jobs/{$name}Job.php");
+    }
+
+    protected function replacePlaceholders(string $content, string $name): string
+    {
+        $pluralName     = Str::plural($name);
+        $domainVariable = Str::camel($name);
+
+        return str_replace(
+            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
+            [$name, $pluralName, $domainVariable],
+            $content
+        );
+    }
+
+    protected function getStub(string $stub): string
+    {
+        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
+
+        if (! $this->files->exists($stubPath)) {
+            throw new \Exception("Stub file not found: {$stubPath}");
+        }
+
+        return $this->files->get($stubPath);
+    }
+}

--- a/src/Commands/MakeListenerCommand.php
+++ b/src/Commands/MakeListenerCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace PlinCode\LaravelCleanArchitecture\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+class MakeListenerCommand extends Command
+{
+    protected $signature = 'clean-arch:make-listener {name : The name of the listener}
+                          {--force : Overwrite existing files}';
+
+    protected $description = 'Create a new listener in the Application layer';
+
+    protected Filesystem $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+        $this->files = $files;
+    }
+
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+
+        $this->info("Creating listener: {$name}");
+        $this->createListener($name);
+        $this->info("Listener {$name} created successfully!");
+
+        return self::SUCCESS;
+    }
+
+    protected function createListener(string $name): void
+    {
+        $stub    = $this->getStub('listener');
+        $content = $this->replacePlaceholders($stub, $name);
+
+        $listenerPath = app_path('Application/Listeners');
+
+        if (! $this->files->isDirectory($listenerPath)) {
+            $this->files->makeDirectory($listenerPath, 0755, true);
+        }
+
+        $this->files->put("{$listenerPath}/{$name}Listener.php", $content);
+        $this->info("Created: Application/Listeners/{$name}Listener.php");
+    }
+
+    protected function replacePlaceholders(string $content, string $name): string
+    {
+        $pluralName     = Str::plural($name);
+        $domainVariable = Str::camel($name);
+
+        return str_replace(
+            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
+            [$name, $pluralName, $domainVariable],
+            $content
+        );
+    }
+
+    protected function getStub(string $stub): string
+    {
+        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
+
+        if (! $this->files->exists($stubPath)) {
+            throw new \Exception("Stub file not found: {$stubPath}");
+        }
+
+        return $this->files->get($stubPath);
+    }
+}

--- a/src/Commands/MakeMailCommand.php
+++ b/src/Commands/MakeMailCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace PlinCode\LaravelCleanArchitecture\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+class MakeMailCommand extends Command
+{
+    protected $signature = 'clean-arch:make-mail {name : The name of the mailable}
+                          {--force : Overwrite existing files}';
+
+    protected $description = 'Create a new mailable in the Infrastructure layer';
+
+    protected Filesystem $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+        $this->files = $files;
+    }
+
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+
+        $this->info("Creating mailable: {$name}");
+        $this->createMail($name);
+        $this->info("Mailable {$name} created successfully!");
+
+        return self::SUCCESS;
+    }
+
+    protected function createMail(string $name): void
+    {
+        $stub    = $this->getStub('mail');
+        $content = $this->replacePlaceholders($stub, $name);
+
+        $mailPath = app_path('Infrastructure/Mail');
+
+        if (! $this->files->isDirectory($mailPath)) {
+            $this->files->makeDirectory($mailPath, 0755, true);
+        }
+
+        $this->files->put("{$mailPath}/{$name}Mail.php", $content);
+        $this->info("Created: Infrastructure/Mail/{$name}Mail.php");
+    }
+
+    protected function replacePlaceholders(string $content, string $name): string
+    {
+        $pluralName     = Str::plural($name);
+        $domainVariable = Str::camel($name);
+
+        return str_replace(
+            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
+            [$name, $pluralName, $domainVariable],
+            $content
+        );
+    }
+
+    protected function getStub(string $stub): string
+    {
+        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
+
+        if (! $this->files->exists($stubPath)) {
+            throw new \Exception("Stub file not found: {$stubPath}");
+        }
+
+        return $this->files->get($stubPath);
+    }
+}

--- a/src/Commands/MakeNotificationCommand.php
+++ b/src/Commands/MakeNotificationCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace PlinCode\LaravelCleanArchitecture\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+class MakeNotificationCommand extends Command
+{
+    protected $signature = 'clean-arch:make-notification {name : The name of the notification}
+                          {--force : Overwrite existing files}';
+
+    protected $description = 'Create a new notification in the Infrastructure layer';
+
+    protected Filesystem $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+        $this->files = $files;
+    }
+
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+
+        $this->info("Creating notification: {$name}");
+        $this->createNotification($name);
+        $this->info("Notification {$name} created successfully!");
+
+        return self::SUCCESS;
+    }
+
+    protected function createNotification(string $name): void
+    {
+        $stub    = $this->getStub('notification');
+        $content = $this->replacePlaceholders($stub, $name);
+
+        $notificationPath = app_path('Infrastructure/Notifications');
+
+        if (! $this->files->isDirectory($notificationPath)) {
+            $this->files->makeDirectory($notificationPath, 0755, true);
+        }
+
+        $this->files->put("{$notificationPath}/{$name}Notification.php", $content);
+        $this->info("Created: Infrastructure/Notifications/{$name}Notification.php");
+    }
+
+    protected function replacePlaceholders(string $content, string $name): string
+    {
+        $pluralName     = Str::plural($name);
+        $domainVariable = Str::camel($name);
+
+        return str_replace(
+            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
+            [$name, $pluralName, $domainVariable],
+            $content
+        );
+    }
+
+    protected function getStub(string $stub): string
+    {
+        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
+
+        if (! $this->files->exists($stubPath)) {
+            throw new \Exception("Stub file not found: {$stubPath}");
+        }
+
+        return $this->files->get($stubPath);
+    }
+}

--- a/src/Commands/MakeObserverCommand.php
+++ b/src/Commands/MakeObserverCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace PlinCode\LaravelCleanArchitecture\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+class MakeObserverCommand extends Command
+{
+    protected $signature = 'clean-arch:make-observer {name : The name of the observer}
+                          {domain : The domain name}
+                          {--force : Overwrite existing files}';
+
+    protected $description = 'Create a new observer in the Infrastructure layer';
+
+    protected Filesystem $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+        $this->files = $files;
+    }
+
+    public function handle(): int
+    {
+        $name   = $this->argument('name');
+        $domain = $this->argument('domain');
+
+        $this->info("Creating observer: {$name} for domain: {$domain}");
+        $this->createObserver($name, $domain);
+        $this->info("Observer {$name} created successfully!");
+
+        return self::SUCCESS;
+    }
+
+    protected function createObserver(string $name, string $domain): void
+    {
+        $stub    = $this->getStub('observer');
+        $content = $this->replacePlaceholders($stub, $name, $domain);
+
+        $pluralDomain = Str::plural($domain);
+        $observerPath = app_path("Infrastructure/Observers/{$pluralDomain}");
+
+        if (! $this->files->isDirectory($observerPath)) {
+            $this->files->makeDirectory($observerPath, 0755, true);
+        }
+
+        $this->files->put("{$observerPath}/{$name}Observer.php", $content);
+        $this->info("Created: Infrastructure/Observers/{$pluralDomain}/{$name}Observer.php");
+    }
+
+    protected function replacePlaceholders(string $content, string $name, string $domain): string
+    {
+        $pluralDomain   = Str::plural($domain);
+        $domainVariable = Str::camel($domain);
+
+        return str_replace(
+            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
+            [$domain, $pluralDomain, $domainVariable],
+            $content
+        );
+    }
+
+    protected function getStub(string $stub): string
+    {
+        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
+
+        if (! $this->files->exists($stubPath)) {
+            throw new \Exception("Stub file not found: {$stubPath}");
+        }
+
+        return $this->files->get($stubPath);
+    }
+}

--- a/src/Commands/ValidateArchitectureCommand.php
+++ b/src/Commands/ValidateArchitectureCommand.php
@@ -40,10 +40,12 @@ class ValidateArchitectureCommand extends Command
 
         if ($this->violationCount > 0) {
             $this->error("Found {$this->violationCount} violation(s).");
+
             return self::FAILURE;
         }
 
         $this->info('No violations found.');
+
         return self::SUCCESS;
     }
 
@@ -52,6 +54,7 @@ class ValidateArchitectureCommand extends Command
         $path = base_path($directory);
         if (! $this->files->isDirectory($path)) {
             $this->line("  ✓ {$label} (directory not found, skipped)");
+
             return;
         }
 
@@ -88,7 +91,7 @@ class ValidateArchitectureCommand extends Command
             foreach ($lines as $lineNumber => $line) {
                 if (str_contains($line, "use {$importPattern}")) {
                     $relativePath = str_replace(base_path() . '/', '', $file->getRealPath());
-                    $violations[] = "{$relativePath}:" . ($lineNumber + 1) . " → " . trim($line);
+                    $violations[] = "{$relativePath}:" . ($lineNumber + 1) . ' → ' . trim($line);
                 }
             }
         }

--- a/src/Commands/ValidateArchitectureCommand.php
+++ b/src/Commands/ValidateArchitectureCommand.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace PlinCode\LaravelCleanArchitecture\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+class ValidateArchitectureCommand extends Command
+{
+    protected $signature = 'clean-arch:validate';
+
+    protected $description = 'Validate Clean Architecture dependency rules';
+
+    protected Filesystem $files;
+
+    protected int $violationCount = 0;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+        $this->files = $files;
+    }
+
+    public function handle(): int
+    {
+        $this->info('Clean Architecture Validation');
+        $this->info('=============================');
+        $this->newLine();
+
+        $this->runImportCheck('Domain has no Application imports', 'app/Domain', 'App\\Application\\');
+        $this->runImportCheck('Domain has no Infrastructure imports', 'app/Domain', 'App\\Infrastructure\\');
+        $this->runImportCheck('Application has no Infrastructure imports', 'app/Application', 'App\\Infrastructure\\');
+        $this->runFilePatternCheck('No Observers in Domain', 'app/Domain', '*Observer*');
+        $this->runFilePatternCheck('No Jobs in Infrastructure', 'app/Infrastructure', '*Job*');
+        $this->runFilePatternCheck('No Commands in Infrastructure', 'app/Infrastructure', '*Command*');
+        $this->runDirectoryCheck('No duplicate Services directory', 'app/Infrastructure/Services');
+
+        $this->newLine();
+
+        if ($this->violationCount > 0) {
+            $this->error("Found {$this->violationCount} violation(s).");
+            return self::FAILURE;
+        }
+
+        $this->info('No violations found.');
+        return self::SUCCESS;
+    }
+
+    protected function runImportCheck(string $label, string $directory, string $pattern): void
+    {
+        $path = base_path($directory);
+        if (! $this->files->isDirectory($path)) {
+            $this->line("  ✓ {$label} (directory not found, skipped)");
+            return;
+        }
+
+        $violations = $this->checkImportViolations($directory, $pattern);
+
+        if (empty($violations)) {
+            $this->line("  ✓ {$label}");
+        } else {
+            $count = count($violations);
+            $this->violationCount += $count;
+            $this->line("  ✗ {$label} ({$count} violation(s))");
+            foreach ($violations as $violation) {
+                $this->line("    - {$violation}");
+            }
+        }
+    }
+
+    public function checkImportViolations(string $directory, string $importPattern): array
+    {
+        $violations = [];
+        $path       = base_path($directory);
+
+        if (! $this->files->isDirectory($path)) {
+            return $violations;
+        }
+
+        $finder = new Finder;
+        $finder->files()->in($path)->name('*.php');
+
+        foreach ($finder as $file) {
+            $contents = $file->getContents();
+            $lines    = explode("\n", $contents);
+
+            foreach ($lines as $lineNumber => $line) {
+                if (str_contains($line, "use {$importPattern}")) {
+                    $relativePath = str_replace(base_path() . '/', '', $file->getRealPath());
+                    $violations[] = "{$relativePath}:" . ($lineNumber + 1) . " → " . trim($line);
+                }
+            }
+        }
+
+        return $violations;
+    }
+
+    protected function runFilePatternCheck(string $label, string $directory, string $pattern): void
+    {
+        $violations = $this->checkFilePatternViolations($directory, $pattern);
+
+        if (empty($violations)) {
+            $this->line("  ✓ {$label}");
+        } else {
+            $count = count($violations);
+            $this->violationCount += $count;
+            $this->line("  ✗ {$label} ({$count} violation(s))");
+            foreach ($violations as $violation) {
+                $this->line("    - {$violation}");
+            }
+        }
+    }
+
+    public function checkFilePatternViolations(string $directory, string $pattern): array
+    {
+        $violations = [];
+        $path       = base_path($directory);
+
+        if (! $this->files->isDirectory($path)) {
+            return $violations;
+        }
+
+        $finder = new Finder;
+        $finder->files()->in($path)->name($pattern);
+
+        foreach ($finder as $file) {
+            $relativePath = str_replace(base_path() . '/', '', $file->getRealPath());
+            $violations[] = $relativePath;
+        }
+
+        return $violations;
+    }
+
+    protected function runDirectoryCheck(string $label, string $directory): void
+    {
+        if ($this->checkDirectoryNotExists($directory)) {
+            $this->violationCount++;
+            $this->line("  ✗ {$label}");
+            $this->line("    - {$directory} exists");
+        } else {
+            $this->line("  ✓ {$label}");
+        }
+    }
+
+    public function checkDirectoryNotExists(string $directory): bool
+    {
+        return $this->files->isDirectory(base_path($directory));
+    }
+}

--- a/stubs/action.stub
+++ b/stubs/action.stub
@@ -3,8 +3,8 @@
 namespace App\Application\Actions\{{PluralDomainName}};
 
 use App\Application\Actions\BaseAction;
-use App\Domain\{{PluralDomainName}}\{{DomainName}};
-use App\Infrastructure\API\Requests\{{RequestName}};
+use App\Domain\{{PluralDomainName}}\Models\{{DomainName}};
+use App\Infrastructure\Http\Requests\{{RequestName}};
 use Illuminate\Support\Facades\DB;
 
 class {{ActionName}} extends BaseAction

--- a/stubs/base-controller.stub
+++ b/stubs/base-controller.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Infrastructure\API\Controllers;
+namespace App\Infrastructure\Http\Controllers;
 
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Validation\ValidatesRequests;

--- a/stubs/base-request.stub
+++ b/stubs/base-request.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Infrastructure\API\Requests;
+namespace App\Infrastructure\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;

--- a/stubs/controller.stub
+++ b/stubs/controller.stub
@@ -1,16 +1,16 @@
 <?php
 
-namespace App\Infrastructure\API\Controllers;
+namespace App\Infrastructure\Http\Controllers\Api;
 
 use App\Application\Actions\{{PluralDomainName}}\Create{{DomainName}}Action;
 use App\Application\Actions\{{PluralDomainName}}\Update{{DomainName}}Action;
 use App\Application\Actions\{{PluralDomainName}}\Delete{{DomainName}}Action;
 use App\Application\Actions\{{PluralDomainName}}\GetById{{DomainName}}Action;
 use App\Application\Services\{{DomainName}}Service;
-use App\Domain\{{PluralDomainName}}\{{DomainName}};
-use App\Infrastructure\API\Requests\Create{{DomainName}}Request;
-use App\Infrastructure\API\Requests\Update{{DomainName}}Request;
-use App\Infrastructure\API\Resources\{{DomainName}}Resource;
+use App\Domain\{{PluralDomainName}}\Models\{{DomainName}};
+use App\Infrastructure\Http\Requests\Create{{DomainName}}Request;
+use App\Infrastructure\Http\Requests\Update{{DomainName}}Request;
+use App\Infrastructure\Http\Resources\{{DomainName}}Resource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 

--- a/stubs/domain-event.stub
+++ b/stubs/domain-event.stub
@@ -2,7 +2,7 @@
 
 namespace App\Domain\{{PluralDomainName}}\Events;
 
-use App\Domain\{{PluralDomainName}}\{{DomainName}};
+use App\Domain\{{PluralDomainName}}\Models\{{DomainName}};
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;

--- a/stubs/domain-model.stub
+++ b/stubs/domain-model.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Domain\{{PluralDomainName}};
+namespace App\Domain\{{PluralDomainName}}\Models;
 
 use App\Domain\Shared\BaseModel;
 use App\Domain\{{PluralDomainName}}\Enums\{{DomainName}}Status;

--- a/stubs/export.stub
+++ b/stubs/export.stub
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Infrastructure\Exports;
+
+use App\Domain\{{PluralDomainName}}\Models\{{DomainName}};
+use Illuminate\Support\Collection;
+
+class {{DomainName}}Export
+{
+    public function collection(): Collection
+    {
+        return {{DomainName}}::all();
+    }
+
+    public function headings(): array
+    {
+        return [
+            'ID',
+            'Name',
+            'Status',
+            'Created At',
+        ];
+    }
+}

--- a/stubs/job.stub
+++ b/stubs/job.stub
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Application\Jobs;
+
+use App\Domain\{{PluralDomainName}}\Models\{{DomainName}};
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class Process{{DomainName}}Job implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public {{DomainName}} ${{domainVariable}}
+    ) {}
+
+    public function handle(): void
+    {
+        //
+    }
+}

--- a/stubs/listener.stub
+++ b/stubs/listener.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Application\Listeners;
+
+use App\Domain\{{PluralDomainName}}\Events\{{DomainName}}Created;
+
+class {{DomainName}}EventListener
+{
+    public function handle({{DomainName}}Created $event): void
+    {
+        //
+    }
+}

--- a/stubs/mail.stub
+++ b/stubs/mail.stub
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Infrastructure\Mail;
+
+use App\Domain\{{PluralDomainName}}\Models\{{DomainName}};
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class {{DomainName}}Mail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public {{DomainName}} ${{domainVariable}}
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '{{DomainName}} Notification',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.{{domainVariable}}',
+        );
+    }
+}

--- a/stubs/notification.stub
+++ b/stubs/notification.stub
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Infrastructure\Notifications;
+
+use App\Domain\{{PluralDomainName}}\Models\{{DomainName}};
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class {{DomainName}}Notification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        public {{DomainName}} ${{domainVariable}}
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->line('{{DomainName}} notification.');
+    }
+}

--- a/stubs/observer.stub
+++ b/stubs/observer.stub
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Infrastructure\Observers\{{PluralDomainName}};
+
+use App\Domain\{{PluralDomainName}}\Models\{{DomainName}};
+
+class {{DomainName}}Observer
+{
+    public function created({{DomainName}} ${{domainVariable}}): void
+    {
+        //
+    }
+
+    public function updated({{DomainName}} ${{domainVariable}}): void
+    {
+        //
+    }
+
+    public function deleted({{DomainName}} ${{domainVariable}}): void
+    {
+        //
+    }
+}

--- a/stubs/readme.stub
+++ b/stubs/readme.stub
@@ -15,8 +15,9 @@ app/
 ├── Domain/              # Business logic
 │   └── Shared/          # Shared classes between domains
 └── Infrastructure/      # Implementation details
-    ├── API/
-    │   ├── Controllers/ # API controllers
+    ├── Http/
+    │   ├── Controllers/
+    │   │   └── Api/    # API controllers
     │   ├── Requests/    # Form requests
     │   └── Resources/   # API resources
     ├── UI/
@@ -51,6 +52,13 @@ app/
 - `php artisan clean-arch:make-action {name} {domain}` - Create a new action
 - `php artisan clean-arch:make-service {name}` - Create a new service
 - `php artisan clean-arch:make-controller {name}` - Create a new controller
+- `php artisan clean-arch:make-observer {name}` - Create a new observer
+- `php artisan clean-arch:make-listener {name}` - Create a new listener
+- `php artisan clean-arch:make-job {name}` - Create a new job
+- `php artisan clean-arch:make-mail {name}` - Create a new mail
+- `php artisan clean-arch:make-notification {name}` - Create a new notification
+- `php artisan clean-arch:make-export {name}` - Create a new export
+- `php artisan clean-arch:validate` - Validate architecture structure
 
 ## Best Practices
 

--- a/stubs/request.stub
+++ b/stubs/request.stub
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\Infrastructure\API\Requests;
+namespace App\Infrastructure\Http\Requests;
 
-use App\Infrastructure\API\Requests\BaseRequest;
+use App\Infrastructure\Http\Requests\BaseRequest;
 
 class {{RequestName}} extends BaseRequest
 {

--- a/stubs/resource.stub
+++ b/stubs/resource.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Infrastructure\API\Resources;
+namespace App\Infrastructure\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;

--- a/stubs/service.stub
+++ b/stubs/service.stub
@@ -3,7 +3,7 @@
 namespace App\Application\Services;
 
 use App\Application\Services\BaseService;
-use App\Domain\{{PluralDomainName}}\{{DomainName}};
+use App\Domain\{{PluralDomainName}}\Models\{{DomainName}};
 use App\Domain\{{PluralDomainName}}\Enums\{{DomainName}}Status;
 use Illuminate\Database\Eloquent\Collection;
 

--- a/stubs/test.stub
+++ b/stubs/test.stub
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature;
 
-use App\Domain\{{PluralDomainName}}\{{DomainName}};
+use App\Domain\{{PluralDomainName}}\Models\{{DomainName}};
 use App\Domain\{{PluralDomainName}}\Enums\{{DomainName}}Status;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;

--- a/tests/Feature/CommandIntegrationTest.php
+++ b/tests/Feature/CommandIntegrationTest.php
@@ -1,0 +1,239 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+
+describe('Command Integration', function () {
+
+    afterEach(function () {
+        $dirs = [
+            app_path('Domain'),
+            app_path('Application'),
+            app_path('Infrastructure'),
+            base_path('CLEAN_ARCHITECTURE.md'),
+            base_path('packages'),
+        ];
+        foreach ($dirs as $dir) {
+            if (File::isDirectory($dir)) {
+                File::deleteDirectory($dir);
+            } elseif (File::exists($dir)) {
+                File::delete($dir);
+            }
+        }
+
+        // Clean up test Feature directories created by make-domain
+        $testFeatureDirs = [
+            base_path('tests/Feature/Products'),
+            base_path('tests/Feature/Orders'),
+        ];
+        foreach ($testFeatureDirs as $dir) {
+            if (File::isDirectory($dir)) {
+                File::deleteDirectory($dir);
+            }
+        }
+
+        // Clean up migration files created by make-domain
+        $migrationPath = database_path('migrations');
+        if (File::isDirectory($migrationPath)) {
+            foreach (File::files($migrationPath) as $file) {
+                if (str_contains($file->getFilename(), 'create_products_table') ||
+                    str_contains($file->getFilename(), 'create_orders_table')) {
+                    File::delete($file->getRealPath());
+                }
+            }
+        }
+    });
+
+    it('runs install command', function () {
+        $this->artisan('clean-arch:install')
+            ->assertExitCode(0);
+
+        expect(File::isDirectory(app_path('Domain')))->toBeTrue();
+        expect(File::isDirectory(app_path('Application/Actions')))->toBeTrue();
+        expect(File::isDirectory(app_path('Application/Services')))->toBeTrue();
+        expect(File::isDirectory(app_path('Application/Jobs')))->toBeTrue();
+        expect(File::isDirectory(app_path('Application/Listeners')))->toBeTrue();
+        expect(File::isDirectory(app_path('Infrastructure/Http/Controllers/Api')))->toBeTrue();
+        expect(File::isDirectory(app_path('Infrastructure/Http/Requests')))->toBeTrue();
+        expect(File::isDirectory(app_path('Infrastructure/Http/Resources')))->toBeTrue();
+        expect(File::isDirectory(app_path('Infrastructure/Mail')))->toBeTrue();
+        expect(File::isDirectory(app_path('Infrastructure/Notifications')))->toBeTrue();
+        expect(File::isDirectory(app_path('Infrastructure/Observers')))->toBeTrue();
+        expect(File::isDirectory(app_path('Infrastructure/Exports')))->toBeTrue();
+        expect(File::exists(app_path('Domain/Shared/BaseModel.php')))->toBeTrue();
+        expect(File::exists(app_path('Application/Actions/BaseAction.php')))->toBeTrue();
+        expect(File::exists(app_path('Infrastructure/Http/Controllers/Controller.php')))->toBeTrue();
+        expect(File::exists(app_path('Infrastructure/Http/Requests/BaseRequest.php')))->toBeTrue();
+    });
+
+    it('runs make-action command', function () {
+        File::ensureDirectoryExists(app_path('Application/Actions'));
+
+        $this->artisan('clean-arch:make-action', ['name' => 'TestAction', 'domain' => 'User'])
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Application/Actions/Users/TestActionAction.php')))->toBeTrue();
+    });
+
+    it('runs make-service command', function () {
+        File::ensureDirectoryExists(app_path('Application/Services'));
+
+        $this->artisan('clean-arch:make-service', ['name' => 'Test'])
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Application/Services/TestService.php')))->toBeTrue();
+    });
+
+    it('runs make-controller command with api flag', function () {
+        File::ensureDirectoryExists(app_path('Infrastructure/Http/Controllers/Api'));
+
+        $this->artisan('clean-arch:make-controller', ['name' => 'Test', '--api' => true])
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Infrastructure/Http/Controllers/Api/TestController.php')))->toBeTrue();
+    });
+
+    it('runs make-controller command with web flag', function () {
+        $this->artisan('clean-arch:make-controller', ['name' => 'Test', '--web' => true])
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Infrastructure/UI/Web/Controllers/TestController.php')))->toBeTrue();
+    });
+
+    it('runs make-controller command with no flags defaults to api', function () {
+        $this->artisan('clean-arch:make-controller', ['name' => 'Default'])
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Infrastructure/Http/Controllers/Api/DefaultController.php')))->toBeTrue();
+    });
+
+    it('runs make-observer command', function () {
+        $this->artisan('clean-arch:make-observer', ['name' => 'User', 'domain' => 'User'])
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Infrastructure/Observers/Users/UserObserver.php')))->toBeTrue();
+    });
+
+    it('runs make-listener command', function () {
+        $this->artisan('clean-arch:make-listener', ['name' => 'User'])
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Application/Listeners/UserListener.php')))->toBeTrue();
+    });
+
+    it('runs make-job command', function () {
+        $this->artisan('clean-arch:make-job', ['name' => 'User'])
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Application/Jobs/UserJob.php')))->toBeTrue();
+    });
+
+    it('runs make-mail command', function () {
+        $this->artisan('clean-arch:make-mail', ['name' => 'User'])
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Infrastructure/Mail/UserMail.php')))->toBeTrue();
+    });
+
+    it('runs make-notification command', function () {
+        $this->artisan('clean-arch:make-notification', ['name' => 'User'])
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Infrastructure/Notifications/UserNotification.php')))->toBeTrue();
+    });
+
+    it('runs make-export command', function () {
+        $this->artisan('clean-arch:make-export', ['name' => 'User'])
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Infrastructure/Exports/UserExport.php')))->toBeTrue();
+    });
+
+    it('runs validate command on clean project', function () {
+        $this->artisan('clean-arch:validate')
+            ->assertExitCode(0);
+    });
+
+    it('runs validate command and detects import violations', function () {
+        File::ensureDirectoryExists(app_path('Domain/Users/Models'));
+        File::put(
+            app_path('Domain/Users/Models/User.php'),
+            "<?php\n\nnamespace App\\Domain\\Users\\Models;\n\nuse App\\Infrastructure\\Traits\\HasSlug;\n\nclass User {}\n"
+        );
+
+        $this->artisan('clean-arch:validate')
+            ->assertExitCode(1);
+    });
+
+    it('runs validate command and detects file pattern violations', function () {
+        // Create an Observer inside Domain (not allowed)
+        File::ensureDirectoryExists(app_path('Domain/Users'));
+        File::put(app_path('Domain/Users/UserObserver.php'), "<?php\nclass UserObserver {}\n");
+
+        $this->artisan('clean-arch:validate')
+            ->assertExitCode(1);
+    });
+
+    it('runs validate command and detects directory violations', function () {
+        // Create Infrastructure/Services directory (not allowed)
+        File::ensureDirectoryExists(app_path('Infrastructure/Services'));
+        File::put(app_path('Infrastructure/Services/.gitkeep'), '');
+
+        $this->artisan('clean-arch:validate')
+            ->assertExitCode(1);
+    });
+
+    it('runs generate-package command', function () {
+        $packagePath = base_path('packages/test-vendor/test-package');
+
+        $this->artisan('clean-arch:generate-package', ['name' => 'test-package', 'vendor' => 'test-vendor'])
+            ->assertExitCode(0);
+
+        expect(File::isDirectory($packagePath))->toBeTrue();
+        expect(File::exists("{$packagePath}/composer.json"))->toBeTrue();
+        expect(File::exists("{$packagePath}/src/TestPackageServiceProvider.php"))->toBeTrue();
+        expect(File::exists("{$packagePath}/src/TestPackage.php"))->toBeTrue();
+        expect(File::exists("{$packagePath}/src/TestPackageService.php"))->toBeTrue();
+        expect(File::exists("{$packagePath}/README.md"))->toBeTrue();
+    });
+
+    it('runs make-domain command with all prompts declined', function () {
+        $this->artisan('clean-arch:install');
+
+        $this->artisan('clean-arch:make-domain', ['name' => 'Product'])
+            ->expectsConfirmation('Would you like to generate an Observer?', 'no')
+            ->expectsConfirmation('Would you like to generate a Listener?', 'no')
+            ->expectsConfirmation('Would you like to generate a Job?', 'no')
+            ->expectsConfirmation('Would you like to generate a Mail?', 'no')
+            ->expectsConfirmation('Would you like to generate a Notification?', 'no')
+            ->expectsConfirmation('Would you like to generate an Export?', 'no')
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Domain/Products/Models/Product.php')))->toBeTrue();
+        expect(File::exists(app_path('Domain/Products/Enums/ProductStatus.php')))->toBeTrue();
+        expect(File::exists(app_path('Domain/Products/Events/ProductCreated.php')))->toBeTrue();
+        expect(File::exists(app_path('Application/Actions/Products/CreateProductAction.php')))->toBeTrue();
+        expect(File::exists(app_path('Application/Services/ProductService.php')))->toBeTrue();
+        expect(File::exists(app_path('Infrastructure/Http/Controllers/Api/ProductsController.php')))->toBeTrue();
+    });
+
+    it('runs make-domain command with all prompts accepted', function () {
+        $this->artisan('clean-arch:install');
+
+        $this->artisan('clean-arch:make-domain', ['name' => 'Order'])
+            ->expectsConfirmation('Would you like to generate an Observer?', 'yes')
+            ->expectsConfirmation('Would you like to generate a Listener?', 'yes')
+            ->expectsConfirmation('Would you like to generate a Job?', 'yes')
+            ->expectsConfirmation('Would you like to generate a Mail?', 'yes')
+            ->expectsConfirmation('Would you like to generate a Notification?', 'yes')
+            ->expectsConfirmation('Would you like to generate an Export?', 'yes')
+            ->assertExitCode(0);
+
+        expect(File::exists(app_path('Domain/Orders/Models/Order.php')))->toBeTrue();
+        expect(File::exists(app_path('Infrastructure/Observers/Orders/OrderObserver.php')))->toBeTrue();
+        expect(File::exists(app_path('Application/Listeners/OrderEventListener.php')))->toBeTrue();
+        expect(File::exists(app_path('Application/Jobs/ProcessOrderJob.php')))->toBeTrue();
+        expect(File::exists(app_path('Infrastructure/Mail/OrderMail.php')))->toBeTrue();
+        expect(File::exists(app_path('Infrastructure/Notifications/OrderNotification.php')))->toBeTrue();
+        expect(File::exists(app_path('Infrastructure/Exports/OrderExport.php')))->toBeTrue();
+    });
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,7 +1,9 @@
 <?php
 
+use PlinCode\LaravelCleanArchitecture\Tests\TestCase;
+
 uses(
-    PlinCode\LaravelCleanArchitecture\Tests\TestCase::class,
+    TestCase::class,
 )->in('Feature', 'Unit');
 
 // Global imports for all tests

--- a/tests/Unit/Commands/InstallCommandTest.php
+++ b/tests/Unit/Commands/InstallCommandTest.php
@@ -177,11 +177,12 @@ describe('InstallCleanArchitectureCommand', function () {
         $method     = $reflection->getMethod('createDirectoryStructure');
         $method->setAccessible(true);
 
-        $createdDirs = [];
+        $createdDirs    = [];
         $mockFilesystem = mock(Filesystem::class);
         $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
         $mockFilesystem->shouldReceive('makeDirectory')->andReturnUsing(function ($dir) use (&$createdDirs) {
             $createdDirs[] = $dir;
+
             return true;
         });
 

--- a/tests/Unit/Commands/InstallCommandTest.php
+++ b/tests/Unit/Commands/InstallCommandTest.php
@@ -172,6 +172,42 @@ describe('InstallCleanArchitectureCommand', function () {
         expect($result)->toBeNull();
     });
 
+    it('creates the correct v2 directory structure', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('createDirectoryStructure');
+        $method->setAccessible(true);
+
+        $createdDirs = [];
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $mockFilesystem->shouldReceive('makeDirectory')->andReturnUsing(function ($dir) use (&$createdDirs) {
+            $createdDirs[] = $dir;
+            return true;
+        });
+
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+        $method->invoke($this->command);
+
+        $basePath = base_path();
+        expect($createdDirs)->toContain("{$basePath}/app/Domain");
+        expect($createdDirs)->toContain("{$basePath}/app/Application/Actions");
+        expect($createdDirs)->toContain("{$basePath}/app/Application/Services");
+        expect($createdDirs)->toContain("{$basePath}/app/Application/Jobs");
+        expect($createdDirs)->toContain("{$basePath}/app/Application/Listeners");
+        expect($createdDirs)->toContain("{$basePath}/app/Application/Console/Commands");
+        expect($createdDirs)->toContain("{$basePath}/app/Infrastructure/Http/Controllers/Api");
+        expect($createdDirs)->toContain("{$basePath}/app/Infrastructure/Http/Middleware");
+        expect($createdDirs)->toContain("{$basePath}/app/Infrastructure/Http/Requests");
+        expect($createdDirs)->toContain("{$basePath}/app/Infrastructure/Http/Resources");
+        expect($createdDirs)->toContain("{$basePath}/app/Infrastructure/UI");
+        expect($createdDirs)->toContain("{$basePath}/app/Infrastructure/Mail");
+        expect($createdDirs)->toContain("{$basePath}/app/Infrastructure/Notifications");
+        expect($createdDirs)->toContain("{$basePath}/app/Infrastructure/Observers");
+        expect($createdDirs)->toContain("{$basePath}/app/Infrastructure/Exports");
+        expect($createdDirs)->toContain("{$basePath}/app/Infrastructure/Validation");
+        expect($createdDirs)->toContain("{$basePath}/app/Infrastructure/Exceptions");
+    });
+
     it('can create exception classes', function () {
         $reflection = new ReflectionClass($this->command);
         $method     = $reflection->getMethod('createExceptionClasses');

--- a/tests/Unit/Commands/MakeActionCommandTest.php
+++ b/tests/Unit/Commands/MakeActionCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeActionCommand;
 
 describe('MakeActionCommand', function () {
@@ -43,9 +44,9 @@ describe('MakeActionCommand', function () {
 
     it('generates correct action paths', function () {
         // Test pluralization logic for action paths
-        expect(\Illuminate\Support\Str::plural('User'))->toBe('Users');
-        expect(\Illuminate\Support\Str::plural('Category'))->toBe('Categories');
-        expect(\Illuminate\Support\Str::plural('ProductCategory'))->toBe('ProductCategories');
+        expect(Str::plural('User'))->toBe('Users');
+        expect(Str::plural('Category'))->toBe('Categories');
+        expect(Str::plural('ProductCategory'))->toBe('ProductCategories');
     });
 
     it('handles getStub method', function () {

--- a/tests/Unit/Commands/MakeControllerCommandTest.php
+++ b/tests/Unit/Commands/MakeControllerCommandTest.php
@@ -7,6 +7,16 @@ describe('MakeControllerCommand', function () {
     beforeEach(function () {
         $this->filesystem = new Filesystem;
         $this->command    = new MakeControllerCommand($this->filesystem);
+
+        // Mock the output to avoid writeln errors
+        $mockOutput = mock('Symfony\Component\Console\Output\OutputInterface');
+        $mockOutput->shouldReceive('writeln')->andReturn();
+        $mockOutput->shouldReceive('write')->andReturn();
+
+        $reflection     = new ReflectionClass($this->command);
+        $outputProperty = $reflection->getProperty('output');
+        $outputProperty->setAccessible(true);
+        $outputProperty->setValue($this->command, $mockOutput);
     });
 
     it('has correct command signature and description', function () {
@@ -63,5 +73,27 @@ describe('MakeControllerCommand', function () {
         $result = $method->invoke($this->command, 'web-controller');
         expect($result)->toBeString();
         expect($result)->toContain('<?php');
+    });
+
+    it('creates api controller in Http/Controllers/Api directory', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('createApiController');
+        $method->setAccessible(true);
+
+        $writtenPath    = null;
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('exists')->andReturn(true);
+        $mockFilesystem->shouldReceive('get')->andReturn('<?php // controller stub');
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
+        $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPath) {
+            $writtenPath = $path;
+            return true;
+        });
+
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+        $method->invoke($this->command, 'Users');
+
+        expect($writtenPath)->toContain('Infrastructure/Http/Controllers/Api/UsersController.php');
     });
 });

--- a/tests/Unit/Commands/MakeControllerCommandTest.php
+++ b/tests/Unit/Commands/MakeControllerCommandTest.php
@@ -88,6 +88,7 @@ describe('MakeControllerCommand', function () {
         $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
         $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPath) {
             $writtenPath = $path;
+
             return true;
         });
 

--- a/tests/Unit/Commands/MakeDomainCommandTest.php
+++ b/tests/Unit/Commands/MakeDomainCommandTest.php
@@ -133,16 +133,23 @@ describe('MakeDomainCommand', function () {
         $method     = $reflection->getMethod('createController');
         $method->setAccessible(true);
 
-        // Mock filesystem and stub
+        $writtenPath = null;
+
         $mockFilesystem = mock(Filesystem::class);
         $mockFilesystem->shouldReceive('exists')->andReturn(true);
-        $mockFilesystem->shouldReceive('get')->andReturn('<?php namespace App\Infrastructure\API\Controllers; class {{PluralName}}Controller {}');
-        $mockFilesystem->shouldReceive('put')->andReturn(true);
+        $mockFilesystem->shouldReceive('get')->andReturn('<?php namespace App\Infrastructure\Http\Controllers\Api; class {{PluralDomainName}}Controller {}');
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
+        $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPath) {
+            $writtenPath = $path;
+
+            return true;
+        });
 
         $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
 
-        $result = $method->invoke($this->command, 'User');
-        expect($result)->toBeNull(); // Void method returns null
+        $method->invoke($this->command, 'User');
+        expect($writtenPath)->toContain('Infrastructure/Http/Controllers/Api');
     });
 
     it('can create requests', function () {
@@ -150,16 +157,23 @@ describe('MakeDomainCommand', function () {
         $method     = $reflection->getMethod('createRequests');
         $method->setAccessible(true);
 
-        // Mock filesystem and stub
+        $writtenPaths = [];
+
         $mockFilesystem = mock(Filesystem::class);
         $mockFilesystem->shouldReceive('exists')->andReturn(true);
-        $mockFilesystem->shouldReceive('get')->andReturn('<?php namespace App\Infrastructure\API\Requests; class {{RequestName}} {}');
-        $mockFilesystem->shouldReceive('put')->andReturn(true);
+        $mockFilesystem->shouldReceive('get')->andReturn('<?php namespace App\Infrastructure\Http\Requests; class {{RequestName}} {}');
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
+        $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPaths) {
+            $writtenPaths[] = $path;
+
+            return true;
+        });
 
         $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
 
-        $result = $method->invoke($this->command, 'User');
-        expect($result)->toBeNull(); // Void method returns null
+        $method->invoke($this->command, 'User');
+        expect($writtenPaths)->each(fn ($path) => $path->toContain('Infrastructure/Http/Requests'));
     });
 
     it('can create resource', function () {
@@ -167,18 +181,23 @@ describe('MakeDomainCommand', function () {
         $method     = $reflection->getMethod('createResource');
         $method->setAccessible(true);
 
-        // Mock filesystem and stub
+        $writtenPath = null;
+
         $mockFilesystem = mock(Filesystem::class);
         $mockFilesystem->shouldReceive('exists')->andReturn(true);
-        $mockFilesystem->shouldReceive('get')->andReturn('<?php namespace App\Infrastructure\API\Resources; class {{Name}}Resource {}');
+        $mockFilesystem->shouldReceive('get')->andReturn('<?php namespace App\Infrastructure\Http\Resources; class {{DomainName}}Resource {}');
         $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
         $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
-        $mockFilesystem->shouldReceive('put')->andReturn(true);
+        $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPath) {
+            $writtenPath = $path;
+
+            return true;
+        });
 
         $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
 
-        $result = $method->invoke($this->command, 'User');
-        expect($result)->toBeNull(); // Void method returns null
+        $method->invoke($this->command, 'User');
+        expect($writtenPath)->toContain('Infrastructure/Http/Resources');
     });
 
     it('can create tests', function () {
@@ -255,6 +274,174 @@ describe('MakeDomainCommand', function () {
 
         $result = $method->invoke($this->command, 'test-stub');
         expect($result)->toBe($stubContent);
+    });
+
+    it('creates domain model in nested Models directory', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('createDomainModel');
+        $method->setAccessible(true);
+
+        $writtenPath = null;
+
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('exists')->andReturn(true);
+        $mockFilesystem->shouldReceive('get')->andReturn('<?php namespace App\Domain\{{PluralDomainName}}\Models; class {{DomainName}} {}');
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
+        $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPath) {
+            $writtenPath = $path;
+
+            return true;
+        });
+
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+
+        $method->invoke($this->command, 'User');
+        expect($writtenPath)->toContain('Domain/Users/Models/User.php');
+    });
+
+    it('can create observer', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('createObserver');
+        $method->setAccessible(true);
+
+        $writtenPath = null;
+
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('exists')->andReturn(true);
+        $mockFilesystem->shouldReceive('get')->andReturn('<?php class {{DomainName}}Observer {}');
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
+        $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPath) {
+            $writtenPath = $path;
+
+            return true;
+        });
+
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+
+        $method->invoke($this->command, 'User');
+        expect($writtenPath)->toContain('Infrastructure/Observers/Users/UserObserver.php');
+    });
+
+    it('can create listener', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('createListener');
+        $method->setAccessible(true);
+
+        $writtenPath = null;
+
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('exists')->andReturn(true);
+        $mockFilesystem->shouldReceive('get')->andReturn('<?php class {{DomainName}}EventListener {}');
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
+        $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPath) {
+            $writtenPath = $path;
+
+            return true;
+        });
+
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+
+        $method->invoke($this->command, 'User');
+        expect($writtenPath)->toContain('Application/Listeners/UserEventListener.php');
+    });
+
+    it('can create job', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('createJob');
+        $method->setAccessible(true);
+
+        $writtenPath = null;
+
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('exists')->andReturn(true);
+        $mockFilesystem->shouldReceive('get')->andReturn('<?php class Process{{DomainName}}Job {}');
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
+        $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPath) {
+            $writtenPath = $path;
+
+            return true;
+        });
+
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+
+        $method->invoke($this->command, 'User');
+        expect($writtenPath)->toContain('Application/Jobs/ProcessUserJob.php');
+    });
+
+    it('can create mail', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('createMail');
+        $method->setAccessible(true);
+
+        $writtenPath = null;
+
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('exists')->andReturn(true);
+        $mockFilesystem->shouldReceive('get')->andReturn('<?php class {{DomainName}}Mail {}');
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
+        $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPath) {
+            $writtenPath = $path;
+
+            return true;
+        });
+
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+
+        $method->invoke($this->command, 'User');
+        expect($writtenPath)->toContain('Infrastructure/Mail/UserMail.php');
+    });
+
+    it('can create notification', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('createNotification');
+        $method->setAccessible(true);
+
+        $writtenPath = null;
+
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('exists')->andReturn(true);
+        $mockFilesystem->shouldReceive('get')->andReturn('<?php class {{DomainName}}Notification {}');
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
+        $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPath) {
+            $writtenPath = $path;
+
+            return true;
+        });
+
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+
+        $method->invoke($this->command, 'User');
+        expect($writtenPath)->toContain('Infrastructure/Notifications/UserNotification.php');
+    });
+
+    it('can create export', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('createExport');
+        $method->setAccessible(true);
+
+        $writtenPath = null;
+
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('exists')->andReturn(true);
+        $mockFilesystem->shouldReceive('get')->andReturn('<?php class {{DomainName}}Export {}');
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $mockFilesystem->shouldReceive('makeDirectory')->andReturn(true);
+        $mockFilesystem->shouldReceive('put')->andReturnUsing(function ($path) use (&$writtenPath) {
+            $writtenPath = $path;
+
+            return true;
+        });
+
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+
+        $method->invoke($this->command, 'User');
+        expect($writtenPath)->toContain('Infrastructure/Exports/UserExport.php');
     });
 
     it('throws exception when stub file not found', function () {

--- a/tests/Unit/Commands/MakeExportCommandTest.php
+++ b/tests/Unit/Commands/MakeExportCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeExportCommand;
+
+describe('MakeExportCommand', function () {
+    beforeEach(function () {
+        $this->filesystem = new Filesystem;
+        $this->command    = new MakeExportCommand($this->filesystem);
+    });
+
+    it('has correct command signature', function () {
+        expect($this->command->getName())->toBe('clean-arch:make-export');
+    });
+
+    it('has required arguments', function () {
+        $definition = $this->command->getDefinition();
+        expect($definition->hasArgument('name'))->toBeTrue();
+        expect($definition->hasOption('force'))->toBeTrue();
+    });
+
+    it('creates export in correct path', function () {
+        $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->andReturn(true);
+        $filesystem->shouldReceive('get')->andReturn('<?php // {{DomainName}} {{PluralDomainName}}');
+        $filesystem->shouldReceive('isDirectory')->andReturn(false);
+        $filesystem->shouldReceive('makeDirectory')->once();
+        $filesystem->shouldReceive('put')->once()->withArgs(function ($path, $content) {
+            return str_contains($path, 'Infrastructure/Exports/UserExport.php');
+        });
+
+        $command = new MakeExportCommand($filesystem);
+        $command->setLaravel(app());
+        $command->setOutput(new \Illuminate\Console\OutputStyle(
+            new \Symfony\Component\Console\Input\ArrayInput([]),
+            new \Symfony\Component\Console\Output\NullOutput
+        ));
+
+        $reflection = new ReflectionClass($command);
+        $method     = $reflection->getMethod('createExport');
+        $method->setAccessible(true);
+        $method->invoke($command, 'User');
+    });
+
+    it('replaces placeholders correctly', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('replacePlaceholders');
+        $method->setAccessible(true);
+
+        $content = '{{DomainName}} {{PluralDomainName}} {{domainVariable}}';
+        $result  = $method->invoke($this->command, $content, 'User');
+
+        expect($result)
+            ->toContain('User')
+            ->toContain('Users')
+            ->toContain('user')
+            ->not->toContain('{{DomainName}}')
+            ->not->toContain('{{PluralDomainName}}')
+            ->not->toContain('{{domainVariable}}');
+    });
+});

--- a/tests/Unit/Commands/MakeExportCommandTest.php
+++ b/tests/Unit/Commands/MakeExportCommandTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use Illuminate\Console\OutputStyle;
 use Illuminate\Filesystem\Filesystem;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeExportCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 describe('MakeExportCommand', function () {
     beforeEach(function () {
@@ -31,9 +34,9 @@ describe('MakeExportCommand', function () {
 
         $command = new MakeExportCommand($filesystem);
         $command->setLaravel(app());
-        $command->setOutput(new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
-            new \Symfony\Component\Console\Output\NullOutput
+        $command->setOutput(new OutputStyle(
+            new ArrayInput([]),
+            new NullOutput
         ));
 
         $reflection = new ReflectionClass($command);

--- a/tests/Unit/Commands/MakeJobCommandTest.php
+++ b/tests/Unit/Commands/MakeJobCommandTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use Illuminate\Console\OutputStyle;
 use Illuminate\Filesystem\Filesystem;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeJobCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 describe('MakeJobCommand', function () {
     beforeEach(function () {
@@ -31,9 +34,9 @@ describe('MakeJobCommand', function () {
 
         $command = new MakeJobCommand($filesystem);
         $command->setLaravel(app());
-        $command->setOutput(new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
-            new \Symfony\Component\Console\Output\NullOutput
+        $command->setOutput(new OutputStyle(
+            new ArrayInput([]),
+            new NullOutput
         ));
 
         $reflection = new ReflectionClass($command);

--- a/tests/Unit/Commands/MakeJobCommandTest.php
+++ b/tests/Unit/Commands/MakeJobCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeJobCommand;
+
+describe('MakeJobCommand', function () {
+    beforeEach(function () {
+        $this->filesystem = new Filesystem;
+        $this->command    = new MakeJobCommand($this->filesystem);
+    });
+
+    it('has correct command signature', function () {
+        expect($this->command->getName())->toBe('clean-arch:make-job');
+    });
+
+    it('has required arguments', function () {
+        $definition = $this->command->getDefinition();
+        expect($definition->hasArgument('name'))->toBeTrue();
+        expect($definition->hasOption('force'))->toBeTrue();
+    });
+
+    it('creates job in correct path', function () {
+        $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->andReturn(true);
+        $filesystem->shouldReceive('get')->andReturn('<?php // {{DomainName}} {{PluralDomainName}}');
+        $filesystem->shouldReceive('isDirectory')->andReturn(false);
+        $filesystem->shouldReceive('makeDirectory')->once();
+        $filesystem->shouldReceive('put')->once()->withArgs(function ($path, $content) {
+            return str_contains($path, 'Application/Jobs/UserJob.php');
+        });
+
+        $command = new MakeJobCommand($filesystem);
+        $command->setLaravel(app());
+        $command->setOutput(new \Illuminate\Console\OutputStyle(
+            new \Symfony\Component\Console\Input\ArrayInput([]),
+            new \Symfony\Component\Console\Output\NullOutput
+        ));
+
+        $reflection = new ReflectionClass($command);
+        $method     = $reflection->getMethod('createJob');
+        $method->setAccessible(true);
+        $method->invoke($command, 'User');
+    });
+
+    it('replaces placeholders correctly', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('replacePlaceholders');
+        $method->setAccessible(true);
+
+        $content = '{{DomainName}} {{PluralDomainName}} {{domainVariable}}';
+        $result  = $method->invoke($this->command, $content, 'User');
+
+        expect($result)
+            ->toContain('User')
+            ->toContain('Users')
+            ->toContain('user')
+            ->not->toContain('{{DomainName}}')
+            ->not->toContain('{{PluralDomainName}}')
+            ->not->toContain('{{domainVariable}}');
+    });
+});

--- a/tests/Unit/Commands/MakeListenerCommandTest.php
+++ b/tests/Unit/Commands/MakeListenerCommandTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use Illuminate\Console\OutputStyle;
 use Illuminate\Filesystem\Filesystem;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeListenerCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 describe('MakeListenerCommand', function () {
     beforeEach(function () {
@@ -31,9 +34,9 @@ describe('MakeListenerCommand', function () {
 
         $command = new MakeListenerCommand($filesystem);
         $command->setLaravel(app());
-        $command->setOutput(new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
-            new \Symfony\Component\Console\Output\NullOutput
+        $command->setOutput(new OutputStyle(
+            new ArrayInput([]),
+            new NullOutput
         ));
 
         $reflection = new ReflectionClass($command);

--- a/tests/Unit/Commands/MakeListenerCommandTest.php
+++ b/tests/Unit/Commands/MakeListenerCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeListenerCommand;
+
+describe('MakeListenerCommand', function () {
+    beforeEach(function () {
+        $this->filesystem = new Filesystem;
+        $this->command    = new MakeListenerCommand($this->filesystem);
+    });
+
+    it('has correct command signature', function () {
+        expect($this->command->getName())->toBe('clean-arch:make-listener');
+    });
+
+    it('has required arguments', function () {
+        $definition = $this->command->getDefinition();
+        expect($definition->hasArgument('name'))->toBeTrue();
+        expect($definition->hasOption('force'))->toBeTrue();
+    });
+
+    it('creates listener in correct path', function () {
+        $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->andReturn(true);
+        $filesystem->shouldReceive('get')->andReturn('<?php // {{DomainName}} {{PluralDomainName}}');
+        $filesystem->shouldReceive('isDirectory')->andReturn(false);
+        $filesystem->shouldReceive('makeDirectory')->once();
+        $filesystem->shouldReceive('put')->once()->withArgs(function ($path, $content) {
+            return str_contains($path, 'Application/Listeners/UserListener.php');
+        });
+
+        $command = new MakeListenerCommand($filesystem);
+        $command->setLaravel(app());
+        $command->setOutput(new \Illuminate\Console\OutputStyle(
+            new \Symfony\Component\Console\Input\ArrayInput([]),
+            new \Symfony\Component\Console\Output\NullOutput
+        ));
+
+        $reflection = new ReflectionClass($command);
+        $method     = $reflection->getMethod('createListener');
+        $method->setAccessible(true);
+        $method->invoke($command, 'User');
+    });
+
+    it('replaces placeholders correctly', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('replacePlaceholders');
+        $method->setAccessible(true);
+
+        $content = '{{DomainName}} {{PluralDomainName}} {{domainVariable}}';
+        $result  = $method->invoke($this->command, $content, 'User');
+
+        expect($result)
+            ->toContain('User')
+            ->toContain('Users')
+            ->toContain('user')
+            ->not->toContain('{{DomainName}}')
+            ->not->toContain('{{PluralDomainName}}')
+            ->not->toContain('{{domainVariable}}');
+    });
+});

--- a/tests/Unit/Commands/MakeMailCommandTest.php
+++ b/tests/Unit/Commands/MakeMailCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeMailCommand;
+
+describe('MakeMailCommand', function () {
+    beforeEach(function () {
+        $this->filesystem = new Filesystem;
+        $this->command    = new MakeMailCommand($this->filesystem);
+    });
+
+    it('has correct command signature', function () {
+        expect($this->command->getName())->toBe('clean-arch:make-mail');
+    });
+
+    it('has required arguments', function () {
+        $definition = $this->command->getDefinition();
+        expect($definition->hasArgument('name'))->toBeTrue();
+        expect($definition->hasOption('force'))->toBeTrue();
+    });
+
+    it('creates mail in correct path', function () {
+        $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->andReturn(true);
+        $filesystem->shouldReceive('get')->andReturn('<?php // {{DomainName}} {{PluralDomainName}}');
+        $filesystem->shouldReceive('isDirectory')->andReturn(false);
+        $filesystem->shouldReceive('makeDirectory')->once();
+        $filesystem->shouldReceive('put')->once()->withArgs(function ($path, $content) {
+            return str_contains($path, 'Infrastructure/Mail/UserMail.php');
+        });
+
+        $command = new MakeMailCommand($filesystem);
+        $command->setLaravel(app());
+        $command->setOutput(new \Illuminate\Console\OutputStyle(
+            new \Symfony\Component\Console\Input\ArrayInput([]),
+            new \Symfony\Component\Console\Output\NullOutput
+        ));
+
+        $reflection = new ReflectionClass($command);
+        $method     = $reflection->getMethod('createMail');
+        $method->setAccessible(true);
+        $method->invoke($command, 'User');
+    });
+
+    it('replaces placeholders correctly', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('replacePlaceholders');
+        $method->setAccessible(true);
+
+        $content = '{{DomainName}} {{PluralDomainName}} {{domainVariable}}';
+        $result  = $method->invoke($this->command, $content, 'User');
+
+        expect($result)
+            ->toContain('User')
+            ->toContain('Users')
+            ->toContain('user')
+            ->not->toContain('{{DomainName}}')
+            ->not->toContain('{{PluralDomainName}}')
+            ->not->toContain('{{domainVariable}}');
+    });
+});

--- a/tests/Unit/Commands/MakeMailCommandTest.php
+++ b/tests/Unit/Commands/MakeMailCommandTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use Illuminate\Console\OutputStyle;
 use Illuminate\Filesystem\Filesystem;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeMailCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 describe('MakeMailCommand', function () {
     beforeEach(function () {
@@ -31,9 +34,9 @@ describe('MakeMailCommand', function () {
 
         $command = new MakeMailCommand($filesystem);
         $command->setLaravel(app());
-        $command->setOutput(new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
-            new \Symfony\Component\Console\Output\NullOutput
+        $command->setOutput(new OutputStyle(
+            new ArrayInput([]),
+            new NullOutput
         ));
 
         $reflection = new ReflectionClass($command);

--- a/tests/Unit/Commands/MakeNotificationCommandTest.php
+++ b/tests/Unit/Commands/MakeNotificationCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeNotificationCommand;
+
+describe('MakeNotificationCommand', function () {
+    beforeEach(function () {
+        $this->filesystem = new Filesystem;
+        $this->command    = new MakeNotificationCommand($this->filesystem);
+    });
+
+    it('has correct command signature', function () {
+        expect($this->command->getName())->toBe('clean-arch:make-notification');
+    });
+
+    it('has required arguments', function () {
+        $definition = $this->command->getDefinition();
+        expect($definition->hasArgument('name'))->toBeTrue();
+        expect($definition->hasOption('force'))->toBeTrue();
+    });
+
+    it('creates notification in correct path', function () {
+        $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->andReturn(true);
+        $filesystem->shouldReceive('get')->andReturn('<?php // {{DomainName}} {{PluralDomainName}}');
+        $filesystem->shouldReceive('isDirectory')->andReturn(false);
+        $filesystem->shouldReceive('makeDirectory')->once();
+        $filesystem->shouldReceive('put')->once()->withArgs(function ($path, $content) {
+            return str_contains($path, 'Infrastructure/Notifications/UserNotification.php');
+        });
+
+        $command = new MakeNotificationCommand($filesystem);
+        $command->setLaravel(app());
+        $command->setOutput(new \Illuminate\Console\OutputStyle(
+            new \Symfony\Component\Console\Input\ArrayInput([]),
+            new \Symfony\Component\Console\Output\NullOutput
+        ));
+
+        $reflection = new ReflectionClass($command);
+        $method     = $reflection->getMethod('createNotification');
+        $method->setAccessible(true);
+        $method->invoke($command, 'User');
+    });
+
+    it('replaces placeholders correctly', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('replacePlaceholders');
+        $method->setAccessible(true);
+
+        $content = '{{DomainName}} {{PluralDomainName}} {{domainVariable}}';
+        $result  = $method->invoke($this->command, $content, 'User');
+
+        expect($result)
+            ->toContain('User')
+            ->toContain('Users')
+            ->toContain('user')
+            ->not->toContain('{{DomainName}}')
+            ->not->toContain('{{PluralDomainName}}')
+            ->not->toContain('{{domainVariable}}');
+    });
+});

--- a/tests/Unit/Commands/MakeNotificationCommandTest.php
+++ b/tests/Unit/Commands/MakeNotificationCommandTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use Illuminate\Console\OutputStyle;
 use Illuminate\Filesystem\Filesystem;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeNotificationCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 describe('MakeNotificationCommand', function () {
     beforeEach(function () {
@@ -31,9 +34,9 @@ describe('MakeNotificationCommand', function () {
 
         $command = new MakeNotificationCommand($filesystem);
         $command->setLaravel(app());
-        $command->setOutput(new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
-            new \Symfony\Component\Console\Output\NullOutput
+        $command->setOutput(new OutputStyle(
+            new ArrayInput([]),
+            new NullOutput
         ));
 
         $reflection = new ReflectionClass($command);

--- a/tests/Unit/Commands/MakeObserverCommandTest.php
+++ b/tests/Unit/Commands/MakeObserverCommandTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use Illuminate\Console\OutputStyle;
 use Illuminate\Filesystem\Filesystem;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeObserverCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 describe('MakeObserverCommand', function () {
     beforeEach(function () {
@@ -32,9 +35,9 @@ describe('MakeObserverCommand', function () {
 
         $command = new MakeObserverCommand($filesystem);
         $command->setLaravel(app());
-        $command->setOutput(new \Illuminate\Console\OutputStyle(
-            new \Symfony\Component\Console\Input\ArrayInput([]),
-            new \Symfony\Component\Console\Output\NullOutput
+        $command->setOutput(new OutputStyle(
+            new ArrayInput([]),
+            new NullOutput
         ));
 
         $reflection = new ReflectionClass($command);

--- a/tests/Unit/Commands/MakeObserverCommandTest.php
+++ b/tests/Unit/Commands/MakeObserverCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeObserverCommand;
+
+describe('MakeObserverCommand', function () {
+    beforeEach(function () {
+        $this->filesystem = new Filesystem;
+        $this->command    = new MakeObserverCommand($this->filesystem);
+    });
+
+    it('has correct command signature', function () {
+        expect($this->command->getName())->toBe('clean-arch:make-observer');
+    });
+
+    it('has required arguments', function () {
+        $definition = $this->command->getDefinition();
+        expect($definition->hasArgument('name'))->toBeTrue();
+        expect($definition->hasArgument('domain'))->toBeTrue();
+        expect($definition->hasOption('force'))->toBeTrue();
+    });
+
+    it('creates observer in correct path', function () {
+        $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->andReturn(true);
+        $filesystem->shouldReceive('get')->andReturn('<?php // {{DomainName}} {{PluralDomainName}}');
+        $filesystem->shouldReceive('isDirectory')->andReturn(false);
+        $filesystem->shouldReceive('makeDirectory')->once();
+        $filesystem->shouldReceive('put')->once()->withArgs(function ($path, $content) {
+            return str_contains($path, 'Infrastructure/Observers/Users/UserObserver.php');
+        });
+
+        $command = new MakeObserverCommand($filesystem);
+        $command->setLaravel(app());
+        $command->setOutput(new \Illuminate\Console\OutputStyle(
+            new \Symfony\Component\Console\Input\ArrayInput([]),
+            new \Symfony\Component\Console\Output\NullOutput
+        ));
+
+        $reflection = new ReflectionClass($command);
+        $method     = $reflection->getMethod('createObserver');
+        $method->setAccessible(true);
+        $method->invoke($command, 'User', 'User');
+    });
+
+    it('replaces placeholders correctly', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('replacePlaceholders');
+        $method->setAccessible(true);
+
+        $content = '{{DomainName}} {{PluralDomainName}} {{domainVariable}}';
+        $result  = $method->invoke($this->command, $content, 'User', 'User');
+
+        expect($result)
+            ->toContain('User')
+            ->toContain('Users')
+            ->toContain('user')
+            ->not->toContain('{{DomainName}}')
+            ->not->toContain('{{PluralDomainName}}')
+            ->not->toContain('{{domainVariable}}');
+    });
+});

--- a/tests/Unit/Commands/ValidateCommandTest.php
+++ b/tests/Unit/Commands/ValidateCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use PlinCode\LaravelCleanArchitecture\Commands\ValidateArchitectureCommand;
+
+describe('ValidateArchitectureCommand', function () {
+    beforeEach(function () {
+        $this->filesystem = new Filesystem;
+        $this->command    = new ValidateArchitectureCommand($this->filesystem);
+
+        $mockOutput = mock('Symfony\Component\Console\Output\OutputInterface');
+        $mockOutput->shouldReceive('writeln')->andReturn();
+        $mockOutput->shouldReceive('write')->andReturn();
+
+        $reflection     = new ReflectionClass($this->command);
+        $outputProperty = $reflection->getProperty('output');
+        $outputProperty->setAccessible(true);
+        $outputProperty->setValue($this->command, $mockOutput);
+    });
+
+    it('has correct command signature', function () {
+        expect($this->command->getName())->toBe('clean-arch:validate');
+    });
+
+    it('has correct description', function () {
+        expect($this->command->getDescription())->toBe('Validate Clean Architecture dependency rules');
+    });
+
+    it('returns empty violations for non-existent directory', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('checkImportViolations');
+        $method->setAccessible(true);
+
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+
+        $violations = $method->invoke($this->command, 'app/Domain', 'App\\Application\\');
+        expect($violations)->toBeArray()->toBeEmpty();
+    });
+
+    it('returns empty violations for non-existent directory in file pattern check', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('checkFilePatternViolations');
+        $method->setAccessible(true);
+
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+
+        $violations = $method->invoke($this->command, 'app/Domain', '*Observer*');
+        expect($violations)->toBeArray()->toBeEmpty();
+    });
+
+    it('detects duplicate services directory when it exists', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('checkDirectoryNotExists');
+        $method->setAccessible(true);
+
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(true);
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+
+        $result = $method->invoke($this->command, 'app/Infrastructure/Services');
+        expect($result)->toBeTrue();
+    });
+
+    it('passes when services directory does not exist in infrastructure', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('checkDirectoryNotExists');
+        $method->setAccessible(true);
+
+        $mockFilesystem = mock(Filesystem::class);
+        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
+        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
+
+        $result = $method->invoke($this->command, 'app/Infrastructure/Services');
+        expect($result)->toBeFalse();
+    });
+});

--- a/tests/Unit/CommandsTest.php
+++ b/tests/Unit/CommandsTest.php
@@ -39,6 +39,48 @@ describe('Commands', function () {
 
         expect($exitCode)->toBe(0);
     });
+
+    it('shows help for make observer command', function () {
+        $exitCode = Artisan::call('clean-arch:make-observer', ['--help' => true]);
+
+        expect($exitCode)->toBe(0);
+    });
+
+    it('shows help for make listener command', function () {
+        $exitCode = Artisan::call('clean-arch:make-listener', ['--help' => true]);
+
+        expect($exitCode)->toBe(0);
+    });
+
+    it('shows help for make job command', function () {
+        $exitCode = Artisan::call('clean-arch:make-job', ['--help' => true]);
+
+        expect($exitCode)->toBe(0);
+    });
+
+    it('shows help for make mail command', function () {
+        $exitCode = Artisan::call('clean-arch:make-mail', ['--help' => true]);
+
+        expect($exitCode)->toBe(0);
+    });
+
+    it('shows help for make notification command', function () {
+        $exitCode = Artisan::call('clean-arch:make-notification', ['--help' => true]);
+
+        expect($exitCode)->toBe(0);
+    });
+
+    it('shows help for make export command', function () {
+        $exitCode = Artisan::call('clean-arch:make-export', ['--help' => true]);
+
+        expect($exitCode)->toBe(0);
+    });
+
+    it('shows help for validate command', function () {
+        $exitCode = Artisan::call('clean-arch:validate', ['--help' => true]);
+
+        expect($exitCode)->toBe(0);
+    });
 });
 
 describe('Command Registration', function () {
@@ -51,7 +93,14 @@ describe('Command Registration', function () {
             ->toHaveKey('clean-arch:make-action')
             ->toHaveKey('clean-arch:make-service')
             ->toHaveKey('clean-arch:make-controller')
-            ->toHaveKey('clean-arch:generate-package');
+            ->toHaveKey('clean-arch:generate-package')
+            ->toHaveKey('clean-arch:make-observer')
+            ->toHaveKey('clean-arch:make-listener')
+            ->toHaveKey('clean-arch:make-job')
+            ->toHaveKey('clean-arch:make-mail')
+            ->toHaveKey('clean-arch:make-notification')
+            ->toHaveKey('clean-arch:make-export')
+            ->toHaveKey('clean-arch:validate');
     });
 
     it('has command instances that extend laravel command class', function () {

--- a/tests/Unit/ServiceProviderTest.php
+++ b/tests/Unit/ServiceProviderTest.php
@@ -7,7 +7,14 @@ use PlinCode\LaravelCleanArchitecture\Commands\InstallCleanArchitectureCommand;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeActionCommand;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeControllerCommand;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeDomainCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeExportCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeJobCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeListenerCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeMailCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeNotificationCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\MakeObserverCommand;
 use PlinCode\LaravelCleanArchitecture\Commands\MakeServiceCommand;
+use PlinCode\LaravelCleanArchitecture\Commands\ValidateArchitectureCommand;
 
 describe('CleanArchitectureServiceProvider', function () {
     it('does not register commands when not running in console', function () {
@@ -27,6 +34,13 @@ describe('CleanArchitectureServiceProvider', function () {
             'clean-arch:make-action'      => MakeActionCommand::class,
             'clean-arch:make-service'     => MakeServiceCommand::class,
             'clean-arch:make-controller'  => MakeControllerCommand::class,
+            'clean-arch:make-observer'    => MakeObserverCommand::class,
+            'clean-arch:make-listener'    => MakeListenerCommand::class,
+            'clean-arch:make-job'         => MakeJobCommand::class,
+            'clean-arch:make-mail'        => MakeMailCommand::class,
+            'clean-arch:make-notification' => MakeNotificationCommand::class,
+            'clean-arch:make-export'      => MakeExportCommand::class,
+            'clean-arch:validate'         => ValidateArchitectureCommand::class,
             'clean-arch:generate-package' => GeneratePackageCommand::class,
         ];
 

--- a/tests/Unit/ServiceProviderTest.php
+++ b/tests/Unit/ServiceProviderTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use PlinCode\LaravelCleanArchitecture\CleanArchitectureServiceProvider;
 use PlinCode\LaravelCleanArchitecture\Commands\GeneratePackageCommand;
@@ -29,25 +30,25 @@ describe('CleanArchitectureServiceProvider', function () {
     it('has correct command instances available', function () {
         $filesystem = new Filesystem;
         $commands   = [
-            'clean-arch:install'          => InstallCleanArchitectureCommand::class,
-            'clean-arch:make-domain'      => MakeDomainCommand::class,
-            'clean-arch:make-action'      => MakeActionCommand::class,
-            'clean-arch:make-service'     => MakeServiceCommand::class,
-            'clean-arch:make-controller'  => MakeControllerCommand::class,
-            'clean-arch:make-observer'    => MakeObserverCommand::class,
-            'clean-arch:make-listener'    => MakeListenerCommand::class,
-            'clean-arch:make-job'         => MakeJobCommand::class,
-            'clean-arch:make-mail'        => MakeMailCommand::class,
+            'clean-arch:install'           => InstallCleanArchitectureCommand::class,
+            'clean-arch:make-domain'       => MakeDomainCommand::class,
+            'clean-arch:make-action'       => MakeActionCommand::class,
+            'clean-arch:make-service'      => MakeServiceCommand::class,
+            'clean-arch:make-controller'   => MakeControllerCommand::class,
+            'clean-arch:make-observer'     => MakeObserverCommand::class,
+            'clean-arch:make-listener'     => MakeListenerCommand::class,
+            'clean-arch:make-job'          => MakeJobCommand::class,
+            'clean-arch:make-mail'         => MakeMailCommand::class,
             'clean-arch:make-notification' => MakeNotificationCommand::class,
-            'clean-arch:make-export'      => MakeExportCommand::class,
-            'clean-arch:validate'         => ValidateArchitectureCommand::class,
-            'clean-arch:generate-package' => GeneratePackageCommand::class,
+            'clean-arch:make-export'       => MakeExportCommand::class,
+            'clean-arch:validate'          => ValidateArchitectureCommand::class,
+            'clean-arch:generate-package'  => GeneratePackageCommand::class,
         ];
 
         foreach ($commands as $signature => $class) {
             $instance = new $class($filesystem);
 
-            expect($instance)->toBeInstanceOf(\Illuminate\Console\Command::class);
+            expect($instance)->toBeInstanceOf(Command::class);
             expect($instance->getName())->toBe($signature);
         }
     });

--- a/tests/Unit/StubsTest.php
+++ b/tests/Unit/StubsTest.php
@@ -18,6 +18,12 @@ describe('Stub Files', function () {
             'request.stub',
             'service.stub',
             'web-controller.stub',
+            'observer.stub',
+            'listener.stub',
+            'job.stub',
+            'mail.stub',
+            'notification.stub',
+            'export.stub',
         ];
 
         foreach ($coreStubs as $stub) {
@@ -60,7 +66,7 @@ describe('Stub Files', function () {
         $content = file_get_contents($this->stubsPath . '/controller.stub');
 
         expect($content)
-            ->toContain('namespace App\Infrastructure\API\Controllers;')
+            ->toContain('namespace App\Infrastructure\Http\Controllers\Api;')
             ->toContain('class {{PluralDomainName}}Controller extends Controller');
     });
 
@@ -76,7 +82,7 @@ describe('Stub Files', function () {
         $content = file_get_contents($this->stubsPath . '/domain-model.stub');
 
         expect($content)
-            ->toContain('namespace App\Domain\{{PluralDomainName}};')
+            ->toContain('namespace App\Domain\{{PluralDomainName}}\Models;')
             ->toContain('class {{DomainName}} extends BaseModel')
             ->toContain('protected $table = \'{{domain-table}}\';')
             ->toContain('protected $fillable')
@@ -88,7 +94,7 @@ describe('Stub Files', function () {
         $content = file_get_contents($this->stubsPath . '/request.stub');
 
         expect($content)
-            ->toContain('namespace App\Infrastructure\API\Requests;')
+            ->toContain('namespace App\Infrastructure\Http\Requests;')
             ->toContain('class {{RequestName}} extends BaseRequest')
             ->toContain('public function rules(): array')
             ->toContain('public function messages(): array');

--- a/tests/Unit/UtilityTest.php
+++ b/tests/Unit/UtilityTest.php
@@ -87,13 +87,13 @@ describe('Utility Methods', function () {
 
         it('creates correct controller paths', function () {
             $controllerPaths = [
-                'User'            => 'app/Infrastructure/API/Controllers/UsersController.php',
-                'ProductCategory' => 'app/Infrastructure/API/Controllers/ProductCategoriesController.php',
-                'Article'         => 'app/Infrastructure/API/Controllers/ArticlesController.php',
+                'User'            => 'app/Infrastructure/Http/Controllers/Api/UsersController.php',
+                'ProductCategory' => 'app/Infrastructure/Http/Controllers/Api/ProductCategoriesController.php',
+                'Article'         => 'app/Infrastructure/Http/Controllers/Api/ArticlesController.php',
             ];
 
             foreach ($controllerPaths as $domain => $expectedPath) {
-                $actualPath = 'app/Infrastructure/API/Controllers/' . Str::plural($domain) . 'Controller.php';
+                $actualPath = 'app/Infrastructure/Http/Controllers/Api/' . Str::plural($domain) . 'Controller.php';
                 expect($actualPath)->toBe($expectedPath);
             }
         });


### PR DESCRIPTION
## Summary

Major version upgrade incorporating a year of production experience with hexagonal architecture patterns.

- **Nested domain structure**: Models, Enums, Events now live in dedicated subdirectories per aggregate (`Domain/{Aggregate}/Models/`, `Enums/`, `Events/`)
- **HTTP consolidation**: All HTTP concerns (controllers, requests, resources, middleware) consolidated under `Infrastructure/Http/`, following Laravel's native structure
- **Interactive `make-domain`**: After generating core files, prompts for optional components (Observer, Listener, Job, Mail, Notification, Export)
- **7 new commands**: `make-observer`, `make-listener`, `make-job`, `make-mail`, `make-notification`, `make-export`, `validate`
- **Architectural validation**: `clean-arch:validate` scans for layer dependency violations (CI friendly, exit code 1 on failure)
- **PHP 8.4+ and Laravel 12+13 support**
- **98.5% test coverage** (156 tests, 467 assertions)

## Breaking Changes

- Domain model namespace changed from `App\Domain\{Aggregate}` to `App\Domain\{Aggregate}\Models`
- Infrastructure paths changed from `Infrastructure/API/` to `Infrastructure/Http/`
- PHP minimum version raised to 8.4