### PR TITLE
fix: remove validate false positives and dead configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ This command checks your codebase for layer dependency violations (for example, 
 
 Checks are based on what the code is, not on how files are named. Imports are read from the real `use` statements of each file, so a trait import inside a class body, a closure `use` clause or a commented out line is never reported. Console commands are recognised by their parent class (`Illuminate\Console\Command`) and jobs by the `Illuminate\Contracts\Queue\ShouldQueue` contract, so a `CommandPaletteController` or a `JobApplicationResource` is left alone. Observers are still matched by the `Observer.php` suffix.
 
+Only the class as written is inspected. A command extending a project specific base class that itself extends `Illuminate\Console\Command` is not reported, and neither is a job extending an abstract base job that implements `ShouldQueue`. The chain is not followed, because resolving it would mean loading application code inside a validation command.
+
 Rules can be disabled one by one, see [Validation rules](#-validation-rules).
 
 ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ php artisan clean-arch:validate
 
 This command checks your codebase for layer dependency violations (for example, Domain code importing from Infrastructure). It returns exit code 1 when violations are found, making it suitable for use in CI pipelines.
 
+Checks are based on what the code is, not on how files are named. Imports are read from the real `use` statements of each file, so a trait import inside a class body, a closure `use` clause or a commented out line is never reported. Console commands are recognised by their parent class (`Illuminate\Console\Command`) and jobs by the `Illuminate\Contracts\Queue\ShouldQueue` contract, so a `CommandPaletteController` or a `JobApplicationResource` is left alone. Observers are still matched by the `Observer.php` suffix.
+
+Rules can be disabled one by one, see [Validation rules](#-validation-rules).
+
 ```
 Clean Architecture Validation
 =============================
@@ -113,7 +117,7 @@ No violations found.
 
 ```
 app/
-├── Domain/                          # Pure business logic
+├── Domain/                          # Business logic (Eloquent models, enums, events)
 ├── Application/                     # Use cases and orchestration
 │   ├── Actions/
 │   ├── Services/
@@ -180,9 +184,15 @@ This package implements Clean Architecture principles:
 
 ### 🔗 Dependencies
 
-- **🎯 Domain Layer**: Does not depend on any other layer
+- **🎯 Domain Layer**: Does not depend on the Application or Infrastructure layers
 - **⚡ Application Layer**: Depends only on Domain Layer
 - **🏗️ Infrastructure Layer**: Depends on Application and Domain Layers
+
+### 🗄️ The Domain layer depends on Eloquent
+
+This is a deliberate trade-off, and it is worth stating explicitly. `clean-arch:install` generates `App\Domain\Shared\BaseModel`, which extends `Illuminate\Database\Eloquent\Model`, and every model produced by `clean-arch:make-domain` extends it. The Domain layer is therefore free of Application and Infrastructure imports (that is what `clean-arch:validate` enforces), but it is not free of the framework.
+
+If you need a persistence agnostic domain, this package is not the right starting point.
 
 ## 💡 Examples
 
@@ -216,12 +226,47 @@ class ProductsController extends Controller
 
 ## ⚙️ Configuration
 
-The configuration file `config/clean-architecture.php` allows you to customize:
+`clean-arch:install` writes `config/clean-architecture.php`. You can also publish it on its own:
 
-- 🏷️ Default namespace
-- 📁 Directory paths
-- ✅ Validation options
-- 📊 Logging settings
+```bash
+php artisan vendor:publish --tag=clean-architecture-config
+```
+
+### 📁 Directories
+
+`directories` is read by `clean-arch:install`, which creates the structure at those paths, and by `clean-arch:validate`, which scans them. The layer namespaces are derived from the same values, so `app/Core/Domain` with a `default_namespace` of `Acme` becomes `Acme\Core\Domain`.
+
+```php
+'default_namespace' => 'App',
+
+'directories' => [
+    'domain' => 'app/Domain',
+    'application' => 'app/Application',
+    'infrastructure' => 'app/Infrastructure',
+],
+```
+
+When the config file is not published, the defaults above are used.
+
+### ✅ Validation rules
+
+Every rule run by `clean-arch:validate` can be turned off by name under `validation.rules`. All of them are enabled by default, so a project without a published config file keeps the full set.
+
+```php
+'validation' => [
+    'rules' => [
+        'domain_no_application_imports' => true,
+        'domain_no_infrastructure_imports' => true,
+        'application_no_infrastructure_imports' => true,
+        'no_observers_in_domain' => true,
+        'no_jobs_in_infrastructure' => true,
+        'no_commands_in_infrastructure' => true,
+        'no_duplicate_services_directory' => true,
+    ],
+],
+```
+
+`no_commands_in_infrastructure` is the most likely candidate for opting out. A console command is an input adapter, much like an HTTP controller, and keeping it in `Application` forces the Application layer to depend on `Illuminate\Console`. Turn the rule off if you prefer `Infrastructure/Console/Commands`.
 
 ## 🛠️ Development
 

--- a/config/clean-architecture.php
+++ b/config/clean-architecture.php
@@ -30,5 +30,21 @@ return [
     'validation' => [
         'strict_mode'     => false,
         'custom_messages' => true,
+
+        /*
+        | Rules run by clean-arch:validate. Every rule is enabled by default,
+        | set one to false to skip it. For example, teams that treat a console
+        | command as an input adapter and keep it next to the HTTP controllers
+        | can turn off 'no_commands_in_infrastructure'.
+        */
+        'rules' => [
+            'domain_no_application_imports'         => true,
+            'domain_no_infrastructure_imports'      => true,
+            'application_no_infrastructure_imports' => true,
+            'no_observers_in_domain'                => true,
+            'no_jobs_in_infrastructure'             => true,
+            'no_commands_in_infrastructure'         => true,
+            'no_duplicate_services_directory'       => true,
+        ],
     ],
 ];

--- a/config/clean-architecture.php
+++ b/config/clean-architecture.php
@@ -11,36 +11,24 @@ return [
     |
     */
 
+    /*
+    | Root namespace of the generated code.
+    */
     'default_namespace' => 'App',
 
+    /*
+    | Paths of the three layers, relative to the base path. They are used by
+    | clean-arch:install to create the structure and by clean-arch:validate to
+    | decide what to scan.
+    */
     'directories' => [
         'domain'         => 'app/Domain',
         'application'    => 'app/Application',
         'infrastructure' => 'app/Infrastructure',
     ],
 
-    'stubs' => [
-        'path' => base_path('stubs/clean-architecture'),
-    ],
-
-    'auto_discovery' => [
-        'enabled' => true,
-        'paths'   => [
-            'app/Application/Actions',
-            'app/Application/Services',
-            'app/Application/Jobs',
-            'app/Application/Listeners',
-            'app/Domain',
-        ],
-    ],
-
     'validation' => [
         'strict_mode'     => false,
         'custom_messages' => true,
-    ],
-
-    'logging' => [
-        'enabled' => true,
-        'channel' => 'daily',
     ],
 ];

--- a/src/Commands/InstallCleanArchitectureCommand.php
+++ b/src/Commands/InstallCleanArchitectureCommand.php
@@ -4,10 +4,13 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use PlinCode\LaravelCleanArchitecture\Concerns\ResolvesArchitectureDirectories;
 
 class InstallCleanArchitectureCommand extends Command
 {
-    protected $signature = 'clean-arch:install 
+    use ResolvesArchitectureDirectories;
+
+    protected $signature = 'clean-arch:install
                           {--force : Overwrite existing files}';
 
     protected $description = 'Install Clean Architecture structure in Laravel project';
@@ -51,24 +54,28 @@ class InstallCleanArchitectureCommand extends Command
 
     protected function createDirectoryStructure(): void
     {
+        $domain         = $this->layerDirectory('domain');
+        $application    = $this->layerDirectory('application');
+        $infrastructure = $this->layerDirectory('infrastructure');
+
         $directories = [
-            'app/Domain',
-            'app/Application/Actions',
-            'app/Application/Services',
-            'app/Application/Jobs',
-            'app/Application/Listeners',
-            'app/Application/Console/Commands',
-            'app/Infrastructure/Http/Controllers/Api',
-            'app/Infrastructure/Http/Middleware',
-            'app/Infrastructure/Http/Requests',
-            'app/Infrastructure/Http/Resources',
-            'app/Infrastructure/UI',
-            'app/Infrastructure/Mail',
-            'app/Infrastructure/Notifications',
-            'app/Infrastructure/Observers',
-            'app/Infrastructure/Exports',
-            'app/Infrastructure/Validation',
-            'app/Infrastructure/Exceptions',
+            $domain,
+            "{$application}/Actions",
+            "{$application}/Services",
+            "{$application}/Jobs",
+            "{$application}/Listeners",
+            "{$application}/Console/Commands",
+            "{$infrastructure}/Http/Controllers/Api",
+            "{$infrastructure}/Http/Middleware",
+            "{$infrastructure}/Http/Requests",
+            "{$infrastructure}/Http/Resources",
+            "{$infrastructure}/UI",
+            "{$infrastructure}/Mail",
+            "{$infrastructure}/Notifications",
+            "{$infrastructure}/Observers",
+            "{$infrastructure}/Exports",
+            "{$infrastructure}/Validation",
+            "{$infrastructure}/Exceptions",
         ];
 
         foreach ($directories as $directory) {
@@ -91,64 +98,63 @@ class InstallCleanArchitectureCommand extends Command
 
     protected function createBaseModel(): void
     {
-        $stub = $this->getStub('base-model');
-        if (! $this->files->isDirectory(app_path('Domain/Shared'))) {
-            $this->files->makeDirectory(app_path('Domain/Shared'), 0755, true);
+        $stub      = $this->getStub('base-model');
+        $directory = $this->layerDirectory('domain') . '/Shared';
+
+        if (! $this->files->isDirectory(base_path($directory))) {
+            $this->files->makeDirectory(base_path($directory), 0755, true);
         }
-        $this->files->put(
-            app_path('Domain/Shared/BaseModel.php'),
-            $stub
-        );
-        $this->info('Created: Domain/Shared/BaseModel.php');
+
+        $this->files->put(base_path("{$directory}/BaseModel.php"), $stub);
+        $this->info("Created: {$directory}/BaseModel.php");
     }
 
     protected function createBaseController(): void
     {
-        $stub = $this->getStub('base-controller');
-        if (! $this->files->isDirectory(app_path('Infrastructure/Http/Controllers'))) {
-            $this->files->makeDirectory(app_path('Infrastructure/Http/Controllers'), 0755, true);
+        $stub      = $this->getStub('base-controller');
+        $directory = $this->layerDirectory('infrastructure') . '/Http/Controllers';
+
+        if (! $this->files->isDirectory(base_path($directory))) {
+            $this->files->makeDirectory(base_path($directory), 0755, true);
         }
-        $this->files->put(
-            app_path('Infrastructure/Http/Controllers/Controller.php'),
-            $stub
-        );
-        $this->info('Created: Infrastructure/Http/Controllers/Controller.php');
+
+        $this->files->put(base_path("{$directory}/Controller.php"), $stub);
+        $this->info("Created: {$directory}/Controller.php");
     }
 
     protected function createBaseAction(): void
     {
-        $stub = $this->getStub('base-action');
-        $this->files->put(
-            app_path('Application/Actions/BaseAction.php'),
-            $stub
-        );
-        $this->info('Created: Application/Actions/BaseAction.php');
+        $stub      = $this->getStub('base-action');
+        $directory = $this->layerDirectory('application') . '/Actions';
+
+        $this->files->put(base_path("{$directory}/BaseAction.php"), $stub);
+        $this->info("Created: {$directory}/BaseAction.php");
     }
 
     protected function createBaseService(): void
     {
-        $stub = $this->getStub('base-service');
-        if (! $this->files->isDirectory(app_path('Application/Services'))) {
-            $this->files->makeDirectory(app_path('Application/Services'), 0755, true);
+        $stub      = $this->getStub('base-service');
+        $directory = $this->layerDirectory('application') . '/Services';
+
+        if (! $this->files->isDirectory(base_path($directory))) {
+            $this->files->makeDirectory(base_path($directory), 0755, true);
         }
-        $this->files->put(
-            app_path('Application/Services/BaseService.php'),
-            $stub
-        );
-        $this->info('Created: Application/Services/BaseService.php');
+
+        $this->files->put(base_path("{$directory}/BaseService.php"), $stub);
+        $this->info("Created: {$directory}/BaseService.php");
     }
 
     protected function createBaseRequest(): void
     {
-        $stub = $this->getStub('base-request');
-        if (! $this->files->isDirectory(app_path('Infrastructure/Http/Requests'))) {
-            $this->files->makeDirectory(app_path('Infrastructure/Http/Requests'), 0755, true);
+        $stub      = $this->getStub('base-request');
+        $directory = $this->layerDirectory('infrastructure') . '/Http/Requests';
+
+        if (! $this->files->isDirectory(base_path($directory))) {
+            $this->files->makeDirectory(base_path($directory), 0755, true);
         }
-        $this->files->put(
-            app_path('Infrastructure/Http/Requests/BaseRequest.php'),
-            $stub
-        );
-        $this->info('Created: Infrastructure/Http/Requests/BaseRequest.php');
+
+        $this->files->put(base_path("{$directory}/BaseRequest.php"), $stub);
+        $this->info("Created: {$directory}/BaseRequest.php");
     }
 
     protected function createExceptionClasses(): void
@@ -159,13 +165,12 @@ class InstallCleanArchitectureCommand extends Command
             'BusinessLogicException' => 'business-logic-exception',
         ];
 
+        $directory = $this->layerDirectory('infrastructure') . '/Exceptions';
+
         foreach ($exceptions as $className => $stub) {
             $content = $this->getStub($stub);
-            $this->files->put(
-                app_path("Infrastructure/Exceptions/{$className}.php"),
-                $content
-            );
-            $this->info("Created: Infrastructure/Exceptions/{$className}.php");
+            $this->files->put(base_path("{$directory}/{$className}.php"), $content);
+            $this->info("Created: {$directory}/{$className}.php");
         }
     }
 

--- a/src/Commands/ValidateArchitectureCommand.php
+++ b/src/Commands/ValidateArchitectureCommand.php
@@ -94,6 +94,9 @@ class ValidateArchitectureCommand extends Command
         }
     }
 
+    /**
+     * @return list<string>
+     */
     public function checkImportViolations(string $directory, string $importPattern): array
     {
         $violations = [];
@@ -103,18 +106,24 @@ class ValidateArchitectureCommand extends Command
             return $violations;
         }
 
+        $prefix = ltrim($importPattern, '\\');
+
         $finder = new Finder;
         $finder->files()->in($path)->name('*.php');
 
         foreach ($finder as $file) {
-            $contents = $file->getContents();
-            $lines    = explode("\n", $contents);
+            $contents     = $file->getContents();
+            $lines        = explode("\n", $contents);
+            $relativePath = str_replace(base_path() . '/', '', $file->getRealPath());
 
-            foreach ($lines as $lineNumber => $line) {
-                if (str_contains($line, "use {$importPattern}")) {
-                    $relativePath = str_replace(base_path() . '/', '', $file->getRealPath());
-                    $violations[] = "{$relativePath}:" . ($lineNumber + 1) . ' → ' . trim($line);
+            foreach ($this->extractUseStatements($contents) as $statement) {
+                if (! str_starts_with($statement['name'], $prefix)) {
+                    continue;
                 }
+
+                $line         = $statement['line'];
+                $source       = trim($lines[$line - 1] ?? '');
+                $violations[] = "{$relativePath}:{$line} → {$source}";
             }
         }
 

--- a/src/Commands/ValidateArchitectureCommand.php
+++ b/src/Commands/ValidateArchitectureCommand.php
@@ -5,11 +5,13 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use PlinCode\LaravelCleanArchitecture\Concerns\ParsesPhpSource;
+use PlinCode\LaravelCleanArchitecture\Concerns\ResolvesArchitectureDirectories;
 use Symfony\Component\Finder\Finder;
 
 class ValidateArchitectureCommand extends Command
 {
     use ParsesPhpSource;
+    use ResolvesArchitectureDirectories;
 
     /**
      * Parent class identifying a console command.
@@ -41,13 +43,17 @@ class ValidateArchitectureCommand extends Command
         $this->info('=============================');
         $this->newLine();
 
-        $this->runImportCheck('Domain has no Application imports', 'app/Domain', 'App\\Application\\');
-        $this->runImportCheck('Domain has no Infrastructure imports', 'app/Domain', 'App\\Infrastructure\\');
-        $this->runImportCheck('Application has no Infrastructure imports', 'app/Application', 'App\\Infrastructure\\');
-        $this->runFilePatternCheck('No Observers in Domain', 'app/Domain', '*Observer.php');
-        $this->reportViolations('No Jobs in Infrastructure', $this->checkQueuedJobViolations('app/Infrastructure'));
-        $this->reportViolations('No Commands in Infrastructure', $this->checkConsoleCommandViolations('app/Infrastructure'));
-        $this->runDirectoryCheck('No duplicate Services directory', 'app/Infrastructure/Services');
+        $domain         = $this->layerDirectory('domain');
+        $application    = $this->layerDirectory('application');
+        $infrastructure = $this->layerDirectory('infrastructure');
+
+        $this->runImportCheck('Domain has no Application imports', $domain, $this->layerNamespace('application'));
+        $this->runImportCheck('Domain has no Infrastructure imports', $domain, $this->layerNamespace('infrastructure'));
+        $this->runImportCheck('Application has no Infrastructure imports', $application, $this->layerNamespace('infrastructure'));
+        $this->runFilePatternCheck('No Observers in Domain', $domain, '*Observer.php');
+        $this->reportViolations('No Jobs in Infrastructure', $this->checkQueuedJobViolations($infrastructure));
+        $this->reportViolations('No Commands in Infrastructure', $this->checkConsoleCommandViolations($infrastructure));
+        $this->runDirectoryCheck('No duplicate Services directory', "{$infrastructure}/Services");
 
         $this->newLine();
 

--- a/src/Commands/ValidateArchitectureCommand.php
+++ b/src/Commands/ValidateArchitectureCommand.php
@@ -47,13 +47,13 @@ class ValidateArchitectureCommand extends Command
         $application    = $this->layerDirectory('application');
         $infrastructure = $this->layerDirectory('infrastructure');
 
-        $this->runImportCheck('Domain has no Application imports', $domain, $this->layerNamespace('application'));
-        $this->runImportCheck('Domain has no Infrastructure imports', $domain, $this->layerNamespace('infrastructure'));
-        $this->runImportCheck('Application has no Infrastructure imports', $application, $this->layerNamespace('infrastructure'));
-        $this->runFilePatternCheck('No Observers in Domain', $domain, '*Observer.php');
-        $this->reportViolations('No Jobs in Infrastructure', $this->checkQueuedJobViolations($infrastructure));
-        $this->reportViolations('No Commands in Infrastructure', $this->checkConsoleCommandViolations($infrastructure));
-        $this->runDirectoryCheck('No duplicate Services directory', "{$infrastructure}/Services");
+        $this->runImportCheck('domain_no_application_imports', 'Domain has no Application imports', $domain, $this->layerNamespace('application'));
+        $this->runImportCheck('domain_no_infrastructure_imports', 'Domain has no Infrastructure imports', $domain, $this->layerNamespace('infrastructure'));
+        $this->runImportCheck('application_no_infrastructure_imports', 'Application has no Infrastructure imports', $application, $this->layerNamespace('infrastructure'));
+        $this->runFilePatternCheck('no_observers_in_domain', 'No Observers in Domain', $domain, '*Observer.php');
+        $this->runClassCheck('no_jobs_in_infrastructure', 'No Jobs in Infrastructure', fn (): array => $this->checkQueuedJobViolations($infrastructure));
+        $this->runClassCheck('no_commands_in_infrastructure', 'No Commands in Infrastructure', fn (): array => $this->checkConsoleCommandViolations($infrastructure));
+        $this->runDirectoryCheck('no_duplicate_services_directory', 'No duplicate Services directory', "{$infrastructure}/Services");
 
         $this->newLine();
 
@@ -68,8 +68,12 @@ class ValidateArchitectureCommand extends Command
         return self::SUCCESS;
     }
 
-    protected function runImportCheck(string $label, string $directory, string $pattern): void
+    protected function runImportCheck(string $rule, string $label, string $directory, string $pattern): void
     {
+        if ($this->skipsRule($rule, $label)) {
+            return;
+        }
+
         $path = base_path($directory);
         if (! $this->files->isDirectory($path)) {
             $this->line("  ✓ {$label} (directory not found, skipped)");
@@ -78,6 +82,40 @@ class ValidateArchitectureCommand extends Command
         }
 
         $this->reportViolations($label, $this->checkImportViolations($directory, $pattern));
+    }
+
+    /**
+     * @param  callable(): list<string>  $violations
+     */
+    protected function runClassCheck(string $rule, string $label, callable $violations): void
+    {
+        if ($this->skipsRule($rule, $label)) {
+            return;
+        }
+
+        $this->reportViolations($label, $violations());
+    }
+
+    /**
+     * Whether a rule is turned off in config/clean-architecture.php.
+     *
+     * Rules are enabled unless explicitly disabled, so a project without a
+     * published config file keeps running all of them.
+     */
+    protected function isRuleEnabled(string $rule): bool
+    {
+        return config("clean-architecture.validation.rules.{$rule}", true) !== false;
+    }
+
+    protected function skipsRule(string $rule, string $label): bool
+    {
+        if ($this->isRuleEnabled($rule)) {
+            return false;
+        }
+
+        $this->line("  - {$label} (disabled)");
+
+        return true;
     }
 
     /**
@@ -136,8 +174,12 @@ class ValidateArchitectureCommand extends Command
         return $violations;
     }
 
-    protected function runFilePatternCheck(string $label, string $directory, string $pattern): void
+    protected function runFilePatternCheck(string $rule, string $label, string $directory, string $pattern): void
     {
+        if ($this->skipsRule($rule, $label)) {
+            return;
+        }
+
         $this->reportViolations($label, $this->checkFilePatternViolations($directory, $pattern));
     }
 
@@ -217,8 +259,12 @@ class ValidateArchitectureCommand extends Command
         return $violations;
     }
 
-    protected function runDirectoryCheck(string $label, string $directory): void
+    protected function runDirectoryCheck(string $rule, string $label, string $directory): void
     {
+        if ($this->skipsRule($rule, $label)) {
+            return;
+        }
+
         if ($this->checkDirectoryNotExists($directory)) {
             $this->violationCount++;
             $this->line("  ✗ {$label}");

--- a/src/Commands/ValidateArchitectureCommand.php
+++ b/src/Commands/ValidateArchitectureCommand.php
@@ -4,10 +4,23 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use PlinCode\LaravelCleanArchitecture\Concerns\ParsesPhpSource;
 use Symfony\Component\Finder\Finder;
 
 class ValidateArchitectureCommand extends Command
 {
+    use ParsesPhpSource;
+
+    /**
+     * Parent class identifying a console command.
+     */
+    protected const CONSOLE_COMMAND_CLASS = 'Illuminate\\Console\\Command';
+
+    /**
+     * Interface identifying a queued job.
+     */
+    protected const SHOULD_QUEUE_INTERFACE = 'Illuminate\\Contracts\\Queue\\ShouldQueue';
+
     protected $signature = 'clean-arch:validate';
 
     protected $description = 'Validate Clean Architecture dependency rules';
@@ -31,9 +44,9 @@ class ValidateArchitectureCommand extends Command
         $this->runImportCheck('Domain has no Application imports', 'app/Domain', 'App\\Application\\');
         $this->runImportCheck('Domain has no Infrastructure imports', 'app/Domain', 'App\\Infrastructure\\');
         $this->runImportCheck('Application has no Infrastructure imports', 'app/Application', 'App\\Infrastructure\\');
-        $this->runFilePatternCheck('No Observers in Domain', 'app/Domain', '*Observer*');
-        $this->runFilePatternCheck('No Jobs in Infrastructure', 'app/Infrastructure', '*Job*');
-        $this->runFilePatternCheck('No Commands in Infrastructure', 'app/Infrastructure', '*Command*');
+        $this->runFilePatternCheck('No Observers in Domain', 'app/Domain', '*Observer.php');
+        $this->reportViolations('No Jobs in Infrastructure', $this->checkQueuedJobViolations('app/Infrastructure'));
+        $this->reportViolations('No Commands in Infrastructure', $this->checkConsoleCommandViolations('app/Infrastructure'));
         $this->runDirectoryCheck('No duplicate Services directory', 'app/Infrastructure/Services');
 
         $this->newLine();
@@ -58,17 +71,26 @@ class ValidateArchitectureCommand extends Command
             return;
         }
 
-        $violations = $this->checkImportViolations($directory, $pattern);
+        $this->reportViolations($label, $this->checkImportViolations($directory, $pattern));
+    }
 
+    /**
+     * @param  list<string>  $violations
+     */
+    protected function reportViolations(string $label, array $violations): void
+    {
         if (empty($violations)) {
             $this->line("  ✓ {$label}");
-        } else {
-            $count = count($violations);
-            $this->violationCount += $count;
-            $this->line("  ✗ {$label} ({$count} violation(s))");
-            foreach ($violations as $violation) {
-                $this->line("    - {$violation}");
-            }
+
+            return;
+        }
+
+        $count = count($violations);
+        $this->violationCount += $count;
+        $this->line("  ✗ {$label} ({$count} violation(s))");
+
+        foreach ($violations as $violation) {
+            $this->line("    - {$violation}");
         }
     }
 
@@ -101,20 +123,12 @@ class ValidateArchitectureCommand extends Command
 
     protected function runFilePatternCheck(string $label, string $directory, string $pattern): void
     {
-        $violations = $this->checkFilePatternViolations($directory, $pattern);
-
-        if (empty($violations)) {
-            $this->line("  ✓ {$label}");
-        } else {
-            $count = count($violations);
-            $this->violationCount += $count;
-            $this->line("  ✗ {$label} ({$count} violation(s))");
-            foreach ($violations as $violation) {
-                $this->line("    - {$violation}");
-            }
-        }
+        $this->reportViolations($label, $this->checkFilePatternViolations($directory, $pattern));
     }
 
+    /**
+     * @return list<string>
+     */
     public function checkFilePatternViolations(string $directory, string $pattern): array
     {
         $violations = [];
@@ -130,6 +144,59 @@ class ValidateArchitectureCommand extends Command
         foreach ($finder as $file) {
             $relativePath = str_replace(base_path() . '/', '', $file->getRealPath());
             $violations[] = $relativePath;
+        }
+
+        return $violations;
+    }
+
+    /**
+     * Find console commands, recognised by their parent class rather than by
+     * their file name, so that a `CommandPaletteController` is not reported.
+     *
+     * @return list<string>
+     */
+    public function checkConsoleCommandViolations(string $directory): array
+    {
+        return $this->checkClassViolations(
+            $directory,
+            fn (array $signature): bool => in_array(self::CONSOLE_COMMAND_CLASS, $signature['extends'], true)
+        );
+    }
+
+    /**
+     * Find queued jobs, recognised by the ShouldQueue contract rather than by
+     * their file name, so that a `JobApplicationResource` is not reported.
+     *
+     * @return list<string>
+     */
+    public function checkQueuedJobViolations(string $directory): array
+    {
+        return $this->checkClassViolations(
+            $directory,
+            fn (array $signature): bool => in_array(self::SHOULD_QUEUE_INTERFACE, $signature['implements'], true)
+        );
+    }
+
+    /**
+     * @param  callable(array{extends: list<string>, implements: list<string>}): bool  $matches
+     * @return list<string>
+     */
+    protected function checkClassViolations(string $directory, callable $matches): array
+    {
+        $violations = [];
+        $path       = base_path($directory);
+
+        if (! $this->files->isDirectory($path)) {
+            return $violations;
+        }
+
+        $finder = new Finder;
+        $finder->files()->in($path)->name('*.php');
+
+        foreach ($finder as $file) {
+            if ($matches($this->parseClassSignature($file->getContents()))) {
+                $violations[] = str_replace(base_path() . '/', '', $file->getRealPath());
+            }
         }
 
         return $violations;

--- a/src/Concerns/ParsesPhpSource.php
+++ b/src/Concerns/ParsesPhpSource.php
@@ -1,0 +1,321 @@
+<?php
+
+namespace PlinCode\LaravelCleanArchitecture\Concerns;
+
+/**
+ * Minimal PHP source analysis built on token_get_all().
+ *
+ * It is intentionally limited to what the architecture checks need: the real
+ * namespace imports of a file and the resolved parent class / interfaces of the
+ * types it declares. No reflection and no autoloading are involved, so files
+ * belonging to the host application never get executed.
+ */
+trait ParsesPhpSource
+{
+    /**
+     * Tokens that carry a piece of a (possibly qualified) name.
+     *
+     * @var list<int>
+     */
+    protected array $nameTokens = [
+        T_STRING,
+        T_NAME_QUALIFIED,
+        T_NAME_FULLY_QUALIFIED,
+        T_NAME_RELATIVE,
+        T_NS_SEPARATOR,
+    ];
+
+    /**
+     * Tokens carrying no semantic value for this analysis.
+     *
+     * @var list<int>
+     */
+    protected array $insignificantTokens = [
+        T_WHITESPACE,
+        T_COMMENT,
+        T_DOC_COMMENT,
+    ];
+
+    /**
+     * Extract the namespace imports of a file.
+     *
+     * Only top level `use` statements are returned, so trait imports inside a
+     * class body, closure `use` clauses, commented out lines and occurrences
+     * inside strings are all ignored. Grouped imports and aliases are expanded.
+     *
+     * @return list<array{name: string, alias: string, line: int}>
+     */
+    protected function extractUseStatements(string $contents): array
+    {
+        $tokens     = token_get_all($contents);
+        $statements = [];
+        $depth      = 0;
+        $previous   = null;
+
+        for ($i = 0, $count = count($tokens); $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if (is_string($token)) {
+                if ($token === '{') {
+                    $depth++;
+                } elseif ($token === '}') {
+                    $depth--;
+                }
+
+                $previous = $token;
+
+                continue;
+            }
+
+            if (in_array($token[0], $this->insignificantTokens, true)) {
+                continue;
+            }
+
+            if ($token[0] === T_CURLY_OPEN || $token[0] === T_DOLLAR_OPEN_CURLY_BRACES) {
+                $depth++;
+                $previous = $token;
+
+                continue;
+            }
+
+            // A `use` keyword preceded by `)` is a closure binding, not an import.
+            if ($token[0] === T_USE && $depth === 0 && $previous !== ')') {
+                $i        = $this->collectUseStatement($tokens, $i, $statements);
+                $previous = ';';
+
+                continue;
+            }
+
+            $previous = $token;
+        }
+
+        return $statements;
+    }
+
+    /**
+     * Resolve the parent class and the interfaces of the types declared in a file.
+     *
+     * @return array{extends: list<string>, implements: list<string>}
+     */
+    protected function parseClassSignature(string $contents): array
+    {
+        $imports = [];
+
+        foreach ($this->extractUseStatements($contents) as $statement) {
+            $imports[strtolower($statement['alias'])] = $statement['name'];
+        }
+
+        $tokens     = token_get_all($contents);
+        $namespace  = '';
+        $extends    = [];
+        $implements = [];
+
+        for ($i = 0, $count = count($tokens); $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if (! is_array($token)) {
+                continue;
+            }
+
+            if ($token[0] === T_NAMESPACE) {
+                [$declared, $i] = $this->readName($tokens, $i + 1);
+                $namespace      = trim($declared, '\\');
+
+                continue;
+            }
+
+            if ($token[0] !== T_EXTENDS && $token[0] !== T_IMPLEMENTS) {
+                continue;
+            }
+
+            $target = $token[0] === T_EXTENDS ? 'extends' : 'implements';
+
+            for ($j = $i + 1; $j < $count; $j++) {
+                $next = $tokens[$j];
+
+                if (is_string($next)) {
+                    if ($next === ',') {
+                        continue;
+                    }
+
+                    break;
+                }
+
+                if (in_array($next[0], $this->insignificantTokens, true)) {
+                    continue;
+                }
+
+                if ($next[0] === T_IMPLEMENTS) {
+                    $target = 'implements';
+
+                    continue;
+                }
+
+                if (! in_array($next[0], $this->nameTokens, true)) {
+                    break;
+                }
+
+                [$name, $j] = $this->readName($tokens, $j);
+                $resolved   = $this->resolveName($name, $namespace, $imports);
+
+                if ($target === 'extends') {
+                    $extends[] = $resolved;
+                } else {
+                    $implements[] = $resolved;
+                }
+            }
+
+            $i = $j;
+        }
+
+        return ['extends' => $extends, 'implements' => $implements];
+    }
+
+    /**
+     * Read the names declared by a single `use` statement.
+     *
+     * @param  array<int, array{0: int, 1: string, 2: int}|string>  $tokens
+     * @param  list<array{name: string, alias: string, line: int}>  $statements
+     * @return int Index of the token closing the statement.
+     */
+    protected function collectUseStatement(array $tokens, int $index, array &$statements): int
+    {
+        $prefix    = '';
+        $current   = '';
+        $alias     = '';
+        $line      = is_array($tokens[$index]) ? $tokens[$index][2] : 1;
+        $readAlias = false;
+
+        for ($i = $index + 1, $count = count($tokens); $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if (is_string($token)) {
+                if ($token === '{') {
+                    $prefix  = $current;
+                    $current = '';
+
+                    continue;
+                }
+
+                if ($token === ',' || $token === '}' || $token === ';') {
+                    $this->pushUseStatement($statements, $prefix . $current, $alias, $line);
+                    $current   = '';
+                    $alias     = '';
+                    $readAlias = false;
+
+                    if ($token === ';') {
+                        return $i;
+                    }
+
+                    continue;
+                }
+
+                continue;
+            }
+
+            if (in_array($token[0], $this->insignificantTokens, true)) {
+                continue;
+            }
+
+            if ($token[0] === T_AS) {
+                $readAlias = true;
+
+                continue;
+            }
+
+            if (! in_array($token[0], $this->nameTokens, true)) {
+                continue;
+            }
+
+            if ($readAlias) {
+                $alias = $token[1];
+
+                continue;
+            }
+
+            if ($current === '') {
+                $line = $token[2];
+            }
+
+            $current .= $token[1];
+        }
+
+        return $count - 1;
+    }
+
+    /**
+     * @param  list<array{name: string, alias: string, line: int}>  $statements
+     */
+    protected function pushUseStatement(array &$statements, string $name, string $alias, int $line): void
+    {
+        $name = trim($name, '\\');
+
+        if ($name === '') {
+            return;
+        }
+
+        $segments = explode('\\', $name);
+
+        $statements[] = [
+            'name'  => $name,
+            'alias' => $alias !== '' ? $alias : (string) end($segments),
+            'line'  => $line,
+        ];
+    }
+
+    /**
+     * Read a (possibly qualified) name starting at the given index.
+     *
+     * @param  array<int, array{0: int, 1: string, 2: int}|string>  $tokens
+     * @return array{0: string, 1: int} The name and the index of its last token.
+     */
+    protected function readName(array $tokens, int $index): array
+    {
+        $name = '';
+        $last = $index;
+
+        for ($i = $index, $count = count($tokens); $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if (! is_array($token)) {
+                break;
+            }
+
+            if ($name === '' && in_array($token[0], $this->insignificantTokens, true)) {
+                continue;
+            }
+
+            if (! in_array($token[0], $this->nameTokens, true)) {
+                break;
+            }
+
+            $name .= $token[1];
+            $last = $i;
+        }
+
+        return [rtrim($name, '\\'), $last];
+    }
+
+    /**
+     * Turn a name written in a class declaration into a fully qualified one.
+     *
+     * @param  array<string, string>  $imports
+     */
+    protected function resolveName(string $name, string $namespace, array $imports): string
+    {
+        $segments = explode('\\', ltrim($name, '\\'));
+        $first    = strtolower($segments[0]);
+
+        if (str_starts_with($name, '\\')) {
+            return implode('\\', $segments);
+        }
+
+        if (isset($imports[$first])) {
+            $segments[0] = $imports[$first];
+
+            return implode('\\', $segments);
+        }
+
+        return $namespace !== '' ? $namespace . '\\' . implode('\\', $segments) : implode('\\', $segments);
+    }
+}

--- a/src/Concerns/ParsesPhpSource.php
+++ b/src/Concerns/ParsesPhpSource.php
@@ -203,6 +203,10 @@ trait ParsesPhpSource
                     $alias     = '';
                     $readAlias = false;
 
+                    if ($token === '}') {
+                        $prefix = '';
+                    }
+
                     if ($token === ';') {
                         return $i;
                     }

--- a/src/Concerns/ResolvesArchitectureDirectories.php
+++ b/src/Concerns/ResolvesArchitectureDirectories.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace PlinCode\LaravelCleanArchitecture\Concerns;
+
+/**
+ * Read the layer directories from config/clean-architecture.php.
+ *
+ * The package config is not merged into the application config, so the values
+ * below are used whenever the file has not been published.
+ */
+trait ResolvesArchitectureDirectories
+{
+    /**
+     * @var array<string, string>
+     */
+    protected array $defaultDirectories = [
+        'domain'         => 'app/Domain',
+        'application'    => 'app/Application',
+        'infrastructure' => 'app/Infrastructure',
+    ];
+
+    /**
+     * Path of a layer, relative to the base path.
+     */
+    protected function layerDirectory(string $layer): string
+    {
+        $configured = config("clean-architecture.directories.{$layer}");
+
+        if (is_string($configured) && trim($configured) !== '') {
+            return trim(trim($configured), '/');
+        }
+
+        return $this->defaultDirectories[$layer];
+    }
+
+    /**
+     * Namespace of a layer, derived from its directory, with a trailing separator.
+     *
+     * `app/Domain` becomes `App\Domain\`, following the psr-4 mapping Laravel
+     * ships with. A leading `app` segment is replaced by the configured root
+     * namespace, any other first segment is kept.
+     */
+    protected function layerNamespace(string $layer): string
+    {
+        $segments = explode('/', $this->layerDirectory($layer));
+
+        if (strtolower((string) reset($segments)) === 'app') {
+            array_shift($segments);
+        }
+
+        $root     = config('clean-architecture.default_namespace');
+        $root     = is_string($root) && trim($root) !== '' ? trim($root, '\\') : 'App';
+        $segments = array_filter(array_merge([$root], $segments), fn (string $segment): bool => $segment !== '');
+
+        return implode('\\', $segments) . '\\';
+    }
+}

--- a/stubs/config.stub
+++ b/stubs/config.stub
@@ -30,5 +30,21 @@ return [
     'validation' => [
         'strict_mode' => false,
         'custom_messages' => true,
+
+        /*
+        | Rules run by clean-arch:validate. Every rule is enabled by default,
+        | set one to false to skip it. For example, teams that treat a console
+        | command as an input adapter and keep it next to the HTTP controllers
+        | can turn off 'no_commands_in_infrastructure'.
+        */
+        'rules' => [
+            'domain_no_application_imports' => true,
+            'domain_no_infrastructure_imports' => true,
+            'application_no_infrastructure_imports' => true,
+            'no_observers_in_domain' => true,
+            'no_jobs_in_infrastructure' => true,
+            'no_commands_in_infrastructure' => true,
+            'no_duplicate_services_directory' => true,
+        ],
     ],
 ];

--- a/stubs/config.stub
+++ b/stubs/config.stub
@@ -11,34 +11,24 @@ return [
     |
     */
 
+    /*
+    | Root namespace of the generated code.
+    */
     'default_namespace' => 'App',
 
+    /*
+    | Paths of the three layers, relative to the base path. They are used by
+    | clean-arch:install to create the structure and by clean-arch:validate to
+    | decide what to scan.
+    */
     'directories' => [
         'domain' => 'app/Domain',
         'application' => 'app/Application',
         'infrastructure' => 'app/Infrastructure',
     ],
 
-    'stubs' => [
-        'path' => base_path('stubs/clean-architecture'),
-    ],
-
-    'auto_discovery' => [
-        'enabled' => true,
-        'paths' => [
-            'app/Application/Actions',
-            'app/Application/Services',
-            'app/Domain',
-        ],
-    ],
-
     'validation' => [
         'strict_mode' => false,
         'custom_messages' => true,
     ],
-
-    'logging' => [
-        'enabled' => true,
-        'channel' => 'daily',
-    ],
-]; 
+];

--- a/stubs/readme.stub
+++ b/stubs/readme.stub
@@ -18,6 +18,7 @@ app/
     ├── Http/
     │   ├── Controllers/
     │   │   └── Api/    # API controllers
+    │   ├── Middleware/  # HTTP middleware
     │   ├── Requests/    # Form requests
     │   └── Resources/   # API resources
     ├── UI/
@@ -25,16 +26,16 @@ app/
     ├── Mail/           # Mail classes
     ├── Notifications/  # Notifications
     ├── Observers/      # Model observers
-    ├── Exceptions/     # Custom exceptions
-    └── Middleware/     # Middleware
+    └── Exceptions/     # Custom exceptions
 ```
 
 ## Principles
 
 ### 1. Domain Layer
-- Contains pure business logic
-- Does not depend on frameworks or external libraries
-- Includes entities, value objects, domain events
+- Contains business logic
+- Does not depend on the Application or Infrastructure layers
+- Depends on Eloquent: models generated here extend `App\Domain\Shared\BaseModel`, which extends `Illuminate\Database\Eloquent\Model`
+- Includes models, enums, domain events
 
 ### 2. Application Layer
 - Use case orchestration

--- a/stubs/readme.stub
+++ b/stubs/readme.stub
@@ -7,26 +7,27 @@ This documentation describes the Clean Architecture structure implemented in the
 ```
 app/
 ├── Application/
-│   ├── Actions/          # Application use cases
-│   ├── Services/         # Application services
-│   ├── Jobs/            # Asynchronous jobs
-│   ├── Console/         # Console commands
-│   └── Listeners/       # Event listeners
-├── Domain/              # Business logic
-│   └── Shared/          # Shared classes between domains
-└── Infrastructure/      # Implementation details
+│   ├── Actions/            # Application use cases
+│   ├── Services/           # Application services
+│   ├── Jobs/               # Asynchronous jobs
+│   ├── Console/Commands/   # Console commands
+│   └── Listeners/          # Event listeners
+├── Domain/                 # Business logic
+│   └── Shared/             # Shared classes between domains
+└── Infrastructure/         # Implementation details
     ├── Http/
     │   ├── Controllers/
-    │   │   └── Api/    # API controllers
-    │   ├── Middleware/  # HTTP middleware
-    │   ├── Requests/    # Form requests
-    │   └── Resources/   # API resources
-    ├── UI/
-    │   └── Web/        # Web controllers
-    ├── Mail/           # Mail classes
-    ├── Notifications/  # Notifications
-    ├── Observers/      # Model observers
-    └── Exceptions/     # Custom exceptions
+    │   │   └── Api/        # API controllers
+    │   ├── Middleware/     # HTTP middleware
+    │   ├── Requests/       # Form requests
+    │   └── Resources/      # API resources
+    ├── UI/                 # Web controllers go in UI/Web/Controllers
+    ├── Mail/               # Mail classes
+    ├── Notifications/      # Notifications
+    ├── Observers/          # Model observers
+    ├── Exports/            # Excel and CSV exports
+    ├── Validation/         # Custom validation rules
+    └── Exceptions/         # Custom exceptions
 ```
 
 ## Principles

--- a/tests/Unit/Commands/ValidateCommandTest.php
+++ b/tests/Unit/Commands/ValidateCommandTest.php
@@ -205,6 +205,90 @@ describe('ValidateArchitectureCommand', function () {
         expect($this->command->checkQueuedJobViolations('app/Infrastructure'))->toBe([$path]);
     });
 
+    it('keeps every rule enabled when the config is not published', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('isRuleEnabled');
+        $method->setAccessible(true);
+
+        expect($method->invoke($this->command, 'no_commands_in_infrastructure'))->toBeTrue();
+        expect($method->invoke($this->command, 'no_duplicate_services_directory'))->toBeTrue();
+    });
+
+    it('reads a disabled rule from the config', function () {
+        config()->set('clean-architecture.validation.rules.no_commands_in_infrastructure', false);
+
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('isRuleEnabled');
+        $method->setAccessible(true);
+
+        expect($method->invoke($this->command, 'no_commands_in_infrastructure'))->toBeFalse();
+        expect($method->invoke($this->command, 'no_jobs_in_infrastructure'))->toBeTrue();
+    });
+
+    it('skips a disabled rule instead of counting violations', function () {
+        config()->set('clean-architecture.validation.rules.no_commands_in_infrastructure', false);
+
+        writeAppFile(
+            'app/Infrastructure/Console/Commands/SyncPractices.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Console\Commands;
+
+            use Illuminate\Console\Command;
+
+            class SyncPractices extends Command {}
+            PHP
+        );
+
+        $reflection = new ReflectionClass($this->command);
+
+        $method = $reflection->getMethod('runClassCheck');
+        $method->setAccessible(true);
+        $method->invoke(
+            $this->command,
+            'no_commands_in_infrastructure',
+            'No Commands in Infrastructure',
+            fn (): array => $this->command->checkConsoleCommandViolations('app/Infrastructure')
+        );
+
+        $violationCount = $reflection->getProperty('violationCount');
+        $violationCount->setAccessible(true);
+
+        expect($violationCount->getValue($this->command))->toBe(0);
+    });
+
+    it('counts violations for the same rule when it stays enabled', function () {
+        writeAppFile(
+            'app/Infrastructure/Console/Commands/SyncPractices.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Console\Commands;
+
+            use Illuminate\Console\Command;
+
+            class SyncPractices extends Command {}
+            PHP
+        );
+
+        $reflection = new ReflectionClass($this->command);
+
+        $method = $reflection->getMethod('runClassCheck');
+        $method->setAccessible(true);
+        $method->invoke(
+            $this->command,
+            'no_commands_in_infrastructure',
+            'No Commands in Infrastructure',
+            fn (): array => $this->command->checkConsoleCommandViolations('app/Infrastructure')
+        );
+
+        $violationCount = $reflection->getProperty('violationCount');
+        $violationCount->setAccessible(true);
+
+        expect($violationCount->getValue($this->command))->toBe(1);
+    });
+
     it('falls back to the default directories when the config is not published', function () {
         $reflection = new ReflectionClass($this->command);
         $method     = $reflection->getMethod('layerDirectory');

--- a/tests/Unit/Commands/ValidateCommandTest.php
+++ b/tests/Unit/Commands/ValidateCommandTest.php
@@ -3,6 +3,19 @@
 use Illuminate\Filesystem\Filesystem;
 use PlinCode\LaravelCleanArchitecture\Commands\ValidateArchitectureCommand;
 
+/**
+ * Write a PHP file inside the testbench application and return its path
+ * relative to the base path.
+ */
+function writeAppFile(string $relativePath, string $contents): string
+{
+    $path = base_path($relativePath);
+    (new Filesystem)->ensureDirectoryExists(dirname($path));
+    (new Filesystem)->put($path, $contents);
+
+    return $relativePath;
+}
+
 describe('ValidateArchitectureCommand', function () {
     beforeEach(function () {
         $this->filesystem = new Filesystem;
@@ -16,6 +29,11 @@ describe('ValidateArchitectureCommand', function () {
         $outputProperty = $reflection->getProperty('output');
         $outputProperty->setAccessible(true);
         $outputProperty->setValue($this->command, $mockOutput);
+    });
+
+    afterEach(function () {
+        $this->filesystem->deleteDirectory(base_path('app/Infrastructure'));
+        $this->filesystem->deleteDirectory(base_path('app/Domain'));
     });
 
     it('has correct command signature', function () {
@@ -76,5 +94,140 @@ describe('ValidateArchitectureCommand', function () {
 
         $result = $method->invoke($this->command, 'app/Infrastructure/Services');
         expect($result)->toBeFalse();
+    });
+
+    it('does not report a business class whose name merely contains Command', function () {
+        writeAppFile(
+            'app/Infrastructure/Http/Controllers/Api/CommandPaletteController.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Http\Controllers\Api;
+
+            class CommandPaletteController
+            {
+                public function index(): void {}
+            }
+            PHP
+        );
+
+        expect($this->command->checkConsoleCommandViolations('app/Infrastructure'))->toBeEmpty();
+    });
+
+    it('reports a class extending the Illuminate console command', function () {
+        $path = writeAppFile(
+            'app/Infrastructure/Console/Commands/SyncPractices.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Console\Commands;
+
+            use Illuminate\Console\Command;
+
+            class SyncPractices extends Command
+            {
+                protected $signature = 'sync:practices';
+            }
+            PHP
+        );
+
+        expect($this->command->checkConsoleCommandViolations('app/Infrastructure'))->toBe([$path]);
+    });
+
+    it('reports a class extending the fully qualified console command', function () {
+        $path = writeAppFile(
+            'app/Infrastructure/Console/Commands/PruneCache.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Console\Commands;
+
+            class PruneCache extends \Illuminate\Console\Command {}
+            PHP
+        );
+
+        expect($this->command->checkConsoleCommandViolations('app/Infrastructure'))->toBe([$path]);
+    });
+
+    it('does not report a business class whose name merely contains Job', function () {
+        writeAppFile(
+            'app/Infrastructure/Http/Resources/JobApplicationResource.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Http\Resources;
+
+            class JobApplicationResource {}
+            PHP
+        );
+
+        expect($this->command->checkQueuedJobViolations('app/Infrastructure'))->toBeEmpty();
+    });
+
+    it('reports a class implementing ShouldQueue', function () {
+        $path = writeAppFile(
+            'app/Infrastructure/Notifications/SendReport.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Notifications;
+
+            use Illuminate\Contracts\Queue\ShouldQueue;
+
+            class SendReport implements ShouldQueue
+            {
+                public function handle(): void {}
+            }
+            PHP
+        );
+
+        expect($this->command->checkQueuedJobViolations('app/Infrastructure'))->toBe([$path]);
+    });
+
+    it('reports an aliased ShouldQueue implementation', function () {
+        $path = writeAppFile(
+            'app/Infrastructure/Notifications/SendInvoice.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Notifications;
+
+            use Illuminate\Bus\Queueable;
+            use Illuminate\Contracts\Queue\ShouldQueue as Queueable2;
+
+            class SendInvoice implements Queueable2
+            {
+                use Queueable;
+            }
+            PHP
+        );
+
+        expect($this->command->checkQueuedJobViolations('app/Infrastructure'))->toBe([$path]);
+    });
+
+    it('only matches the Observer suffix in domain', function () {
+        writeAppFile(
+            'app/Domain/Practices/Models/ObserverSlot.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Domain\Practices\Models;
+
+            class ObserverSlot {}
+            PHP
+        );
+
+        $path = writeAppFile(
+            'app/Domain/Practices/PracticeObserver.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Domain\Practices;
+
+            class PracticeObserver {}
+            PHP
+        );
+
+        expect($this->command->checkFilePatternViolations('app/Domain', '*Observer.php'))->toBe([$path]);
     });
 });

--- a/tests/Unit/Commands/ValidateCommandTest.php
+++ b/tests/Unit/Commands/ValidateCommandTest.php
@@ -205,6 +205,55 @@ describe('ValidateArchitectureCommand', function () {
         expect($this->command->checkQueuedJobViolations('app/Infrastructure'))->toBe([$path]);
     });
 
+    it('falls back to the default directories when the config is not published', function () {
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('layerDirectory');
+        $method->setAccessible(true);
+
+        expect($method->invoke($this->command, 'domain'))->toBe('app/Domain');
+        expect($method->invoke($this->command, 'application'))->toBe('app/Application');
+        expect($method->invoke($this->command, 'infrastructure'))->toBe('app/Infrastructure');
+    });
+
+    it('reads the configured directories and derives their namespaces', function () {
+        config()->set('clean-architecture.directories.domain', 'app/Core/Domain/');
+        config()->set('clean-architecture.default_namespace', 'Acme');
+
+        $reflection = new ReflectionClass($this->command);
+
+        $directory = $reflection->getMethod('layerDirectory');
+        $directory->setAccessible(true);
+        expect($directory->invoke($this->command, 'domain'))->toBe('app/Core/Domain');
+
+        $namespace = $reflection->getMethod('layerNamespace');
+        $namespace->setAccessible(true);
+        expect($namespace->invoke($this->command, 'domain'))->toBe('Acme\\Core\\Domain\\');
+    });
+
+    it('scans the configured domain directory', function () {
+        config()->set('clean-architecture.directories.domain', 'app/Core');
+
+        $path = writeAppFile(
+            'app/Core/Practices/PracticeObserver.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Core\Practices;
+
+            class PracticeObserver {}
+            PHP
+        );
+
+        $reflection = new ReflectionClass($this->command);
+        $method     = $reflection->getMethod('layerDirectory');
+        $method->setAccessible(true);
+
+        expect($this->command->checkFilePatternViolations($method->invoke($this->command, 'domain'), '*Observer.php'))
+            ->toBe([$path]);
+
+        $this->filesystem->deleteDirectory(base_path('app/Core'));
+    });
+
     it('reports a real infrastructure import in domain', function () {
         $path = writeAppFile(
             'app/Domain/Users/Models/User.php',

--- a/tests/Unit/Commands/ValidateCommandTest.php
+++ b/tests/Unit/Commands/ValidateCommandTest.php
@@ -205,6 +205,106 @@ describe('ValidateArchitectureCommand', function () {
         expect($this->command->checkQueuedJobViolations('app/Infrastructure'))->toBe([$path]);
     });
 
+    it('reports a real infrastructure import in domain', function () {
+        $path = writeAppFile(
+            'app/Domain/Users/Models/User.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Domain\Users\Models;
+
+            use App\Infrastructure\Traits\HasSlug;
+
+            class User
+            {
+                use HasSlug;
+            }
+            PHP
+        );
+
+        expect($this->command->checkImportViolations('app/Domain', 'App\\Infrastructure\\'))
+            ->toBe(["{$path}:5 → use App\\Infrastructure\\Traits\\HasSlug;"]);
+    });
+
+    it('does not report a trait use inside the class body', function () {
+        writeAppFile(
+            'app/Domain/Users/Models/Member.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Domain\Users\Models;
+
+            class Member
+            {
+                use App\Infrastructure\Traits\HasSlug;
+            }
+            PHP
+        );
+
+        expect($this->command->checkImportViolations('app/Domain', 'App\\Infrastructure\\'))->toBeEmpty();
+    });
+
+    it('does not report a commented out import', function () {
+        writeAppFile(
+            'app/Domain/Users/Models/Guest.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Domain\Users\Models;
+
+            // use App\Infrastructure\Foo;
+            /* use App\Infrastructure\Bar; */
+
+            class Guest
+            {
+                public function label(): string
+                {
+                    return 'use App\Infrastructure\Baz;';
+                }
+            }
+            PHP
+        );
+
+        expect($this->command->checkImportViolations('app/Domain', 'App\\Infrastructure\\'))->toBeEmpty();
+    });
+
+    it('does not report a closure use clause', function () {
+        writeAppFile(
+            'app/Domain/Users/bootstrap.php',
+            <<<'PHP'
+            <?php
+
+            $prefix = 'App\Infrastructure\\';
+
+            $callback = function () use ($prefix) {
+                return $prefix;
+            };
+            PHP
+        );
+
+        expect($this->command->checkImportViolations('app/Domain', 'App\\Infrastructure\\'))->toBeEmpty();
+    });
+
+    it('reports every name of a grouped import', function () {
+        $path = writeAppFile(
+            'app/Domain/Users/Models/Team.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Domain\Users\Models;
+
+            use App\Infrastructure\Traits\{HasSlug, HasUuid};
+
+            class Team {}
+            PHP
+        );
+
+        expect($this->command->checkImportViolations('app/Domain', 'App\\Infrastructure\\'))->toBe([
+            "{$path}:5 → use App\\Infrastructure\\Traits\\{HasSlug, HasUuid};",
+            "{$path}:5 → use App\\Infrastructure\\Traits\\{HasSlug, HasUuid};",
+        ]);
+    });
+
     it('only matches the Observer suffix in domain', function () {
         writeAppFile(
             'app/Domain/Practices/Models/ObserverSlot.php',


### PR DESCRIPTION
## Why

The package was used as the initial scaffolding of a real Laravel application, which then grew to 1,837 PHP files, 408 domain files and 258 services. On that codebase `clean-arch:validate` turned out to be unusable for two reasons, and the published config file has no effect at all. This PR fixes only those problems. No new features, no changed defaults.

## What changes

### `clean-arch:validate` no longer reports false positives

The structural checks recognised console commands, jobs and observers from the file name (`*Command*`, `*Job*`, `*Observer*`). Any business entity whose name contained one of those words ended up in the violation list. On a project with a "Command Palette" domain the command reported, among others:

```
app/Infrastructure/Http/Controllers/Api/CommandPaletteController.php
app/Infrastructure/Http/Resources/Practice/CommandPalette/CommandPaletteResultResource.php
app/Infrastructure/Http/Requests/Practice/CommandPalette/SearchCommandPaletteRequest.php
```

None of the three is a console command. Detection is now based on the class (`extends Illuminate\Console\Command`, `implements ShouldQueue`) instead of the file name. Observers keep a name based match, narrowed to the exact `Observer.php` suffix, since there is no reliable signal in the source itself.

### Imports are actually parsed

`checkImportViolations()` ran `str_contains($line, "use {$pattern}")` line by line, so it also reported trait `use` statements inside a class body, commented out lines and occurrences inside a string. Namespace imports are now extracted with `token_get_all()`, including grouped and aliased imports. The returned format (`path:line → line`) is unchanged. No dependency added.

### The published configuration now has an effect

`stubs/config.stub` declared `directories`, `auto_discovery`, `validation`, `logging` and `stubs.path`, while there was not a single call to `config()` anywhere in `src/`. Changing `directories.domain` produced no result, and no error either.

- `directories` is now read by `clean-arch:validate` and `clean-arch:install`, with the current hardcoded values as defaults when the config file is not published. Layer namespaces are derived from the same values.
- The keys that were never implemented have been removed from the stub and from the shipped config.

### Validate rules can be disabled one by one

New `validation.rules` section in the configuration. Every rule stays enabled by default, so behaviour does not change on upgrade.

It exists for legitimate cases such as "No Commands in Infrastructure". A console command is an input adapter exactly like an HTTP controller, and placing it in `Application` forces that layer to depend on `Illuminate\Console`. The project this PR comes from has 81 of them in `Infrastructure/Console/Commands` for that reason. Anyone who disagrees with the rule can now turn it off instead of ignoring the output.

### README aligned with the code

- The README claimed the Domain layer does not depend on frameworks, while `base-model.stub` generates a class extending `Illuminate\Database\Eloquent\Model`. The text now says so explicitly.
- The middleware location was described in two different ways, and neither matched the `app/Infrastructure/Http/Middleware` directory that `clean-arch:install` actually creates.
- The new `validation.rules` section is documented, along with the fact that `directories` is now effective.

## Tests

`tests/Unit/Commands/ValidateCommandTest.php` covers the reported cases: a `CommandPaletteController` is not a violation, a class extending `Illuminate\Console\Command` is, a trait `use` inside a class body and a commented out import are not import violations, and a rule disabled in `validation.rules` is skipped. `composer format`, `composer analyse` and `composer test` all pass (175 tests).

## Compatibility

No breaking changes. Defaults are unchanged, the configuration is optional, and projects that do not publish it behave as before. The only observable difference is that `clean-arch:validate` reports fewer violations, because the ones that disappear were false.
