### PR TITLE
fix(validate): follow inheritance chains across app

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ This command checks your codebase for layer dependency violations (for example, 
 
 Checks are based on what the code is, not on how files are named. Imports are read from the real `use` statements of each file, so a trait import inside a class body, a closure `use` clause or a commented out line is never reported. Console commands are recognised by their parent class (`Illuminate\Console\Command`) and jobs by the `Illuminate\Contracts\Queue\ShouldQueue` contract, so a `CommandPaletteController` or a `JobApplicationResource` is left alone. Observers are still matched by the `Observer.php` suffix.
 
+Inheritance is followed, so a command extending your own `BaseCommand` is reported just like one extending `Illuminate\Console\Command` directly. The chain is resolved by parsing the sources under `app/`, never by loading them, which has one consequence worth knowing: if a class extends something that lives in `vendor/`, the chain stops there and the class is not reported. Only classes are reported, so an interface extending `ShouldQueue` counts as a contract, not as a job.
+
 Rules can be disabled one by one, see [Validation rules](#-validation-rules).
 
 ```

--- a/src/Commands/ValidateArchitectureCommand.php
+++ b/src/Commands/ValidateArchitectureCommand.php
@@ -4,13 +4,13 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use PlinCode\LaravelCleanArchitecture\Concerns\ParsesPhpSource;
+use PlinCode\LaravelCleanArchitecture\Concerns\BuildsClassMap;
 use PlinCode\LaravelCleanArchitecture\Concerns\ResolvesArchitectureDirectories;
 use Symfony\Component\Finder\Finder;
 
 class ValidateArchitectureCommand extends Command
 {
-    use ParsesPhpSource;
+    use BuildsClassMap;
     use ResolvesArchitectureDirectories;
 
     /**
@@ -207,54 +207,62 @@ class ValidateArchitectureCommand extends Command
     }
 
     /**
-     * Find console commands, recognised by their parent class rather than by
-     * their file name, so that a `CommandPaletteController` is not reported.
+     * Find console commands, recognised by their ancestors rather than by their
+     * file name, so that a `CommandPaletteController` is not reported and a
+     * command extending a project specific base class still is.
      *
      * @return list<string>
      */
     public function checkConsoleCommandViolations(string $directory): array
     {
-        return $this->checkClassViolations(
-            $directory,
-            fn (array $signature): bool => in_array(self::CONSOLE_COMMAND_CLASS, $signature['extends'], true)
-        );
+        return $this->checkClassViolations($directory, self::CONSOLE_COMMAND_CLASS);
     }
 
     /**
-     * Find queued jobs, recognised by the ShouldQueue contract rather than by
-     * their file name, so that a `JobApplicationResource` is not reported.
+     * Find queued jobs, recognised by the ShouldQueue contract reached anywhere
+     * in their inheritance chain, so that a `JobApplicationResource` is not
+     * reported and a job extending an abstract base job still is.
      *
      * @return list<string>
      */
     public function checkQueuedJobViolations(string $directory): array
     {
-        return $this->checkClassViolations(
-            $directory,
-            fn (array $signature): bool => in_array(self::SHOULD_QUEUE_INTERFACE, $signature['implements'], true)
-        );
+        return $this->checkClassViolations($directory, self::SHOULD_QUEUE_INTERFACE);
     }
 
     /**
-     * @param  callable(array{extends: list<string>, implements: list<string>}): bool  $matches
+     * Files under a directory declaring a class that descends from an ancestor.
+     *
+     * Only classes count. An interface extending `ShouldQueue` is a contract,
+     * not a job, and reporting it would be noise.
+     *
      * @return list<string>
      */
-    protected function checkClassViolations(string $directory, callable $matches): array
+    protected function checkClassViolations(string $directory, string $ancestor): array
     {
-        $violations = [];
-        $path       = base_path($directory);
+        $path = base_path($directory);
 
         if (! $this->files->isDirectory($path)) {
-            return $violations;
+            return [];
         }
 
-        $finder = new Finder;
-        $finder->files()->in($path)->name('*.php');
+        $prefix     = rtrim($path, '/') . '/';
+        $violations = [];
 
-        foreach ($finder as $file) {
-            if ($matches($this->parseClassSignature($file->getContents()))) {
-                $violations[] = str_replace(base_path() . '/', '', $file->getRealPath());
+        foreach ($this->classMap() as $fqcn => $entry) {
+            if ($entry['kind'] !== 'class' || ! str_starts_with($entry['path'], $prefix)) {
+                continue;
             }
+
+            if (! in_array($ancestor, $this->ancestorsOf($fqcn), true)) {
+                continue;
+            }
+
+            $violations[$entry['path']] = str_replace(base_path() . '/', '', $entry['path']);
         }
+
+        $violations = array_values($violations);
+        sort($violations);
 
         return $violations;
     }

--- a/src/Concerns/BuildsClassMap.php
+++ b/src/Concerns/BuildsClassMap.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace PlinCode\LaravelCleanArchitecture\Concerns;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Build a map of the classes declared by the application and walk their
+ * inheritance chains.
+ *
+ * The map is built by parsing sources, never by autoloading them, so a class
+ * whose parent lives in `vendor/` ends the chain. That is a deliberate limit:
+ * resolving it would mean loading application code inside a validation command.
+ */
+trait BuildsClassMap
+{
+    use ParsesPhpSource;
+
+    /**
+     * @var array<string, array{path: string, kind: string, extends: list<string>, implements: list<string>}>|null
+     */
+    protected ?array $classMap = null;
+
+    /**
+     * Every type declared under the scanned directories, keyed by its FQCN.
+     *
+     * @return array<string, array{path: string, kind: string, extends: list<string>, implements: list<string>}>
+     */
+    protected function classMap(): array
+    {
+        if ($this->classMap !== null) {
+            return $this->classMap;
+        }
+
+        $directories = $this->classMapDirectories();
+
+        if ($directories === []) {
+            return $this->classMap = [];
+        }
+
+        $map = [];
+
+        $finder = new Finder;
+        $finder->files()->in($directories)->name('*.php');
+
+        foreach ($finder as $file) {
+            $path = $file->getRealPath();
+
+            if ($path === false) {
+                continue;
+            }
+
+            foreach ($this->parseClassDeclarations($file->getContents()) as $declaration) {
+                $map[$declaration['fqcn']] = [
+                    'path'       => $path,
+                    'kind'       => $declaration['kind'],
+                    'extends'    => $declaration['extends'],
+                    'implements' => $declaration['implements'],
+                ];
+            }
+        }
+
+        return $this->classMap = $map;
+    }
+
+    /**
+     * Every parent class and interface of a type, transitively.
+     *
+     * @return list<string>
+     */
+    protected function ancestorsOf(string $fqcn): array
+    {
+        $map       = $this->classMap();
+        $ancestors = [];
+        $queue     = [$fqcn];
+        $visited   = [$fqcn => true];
+
+        while ($queue !== []) {
+            $current = array_shift($queue);
+            $entry   = $map[$current] ?? null;
+
+            if ($entry === null) {
+                continue;
+            }
+
+            foreach (array_merge($entry['extends'], $entry['implements']) as $parent) {
+                if (isset($visited[$parent])) {
+                    continue;
+                }
+
+                $visited[$parent] = true;
+                $ancestors[]      = $parent;
+                $queue[]          = $parent;
+            }
+        }
+
+        return $ancestors;
+    }
+
+    /**
+     * Directories parsed to build the map.
+     *
+     * `app` is included on top of the three layers because a base class often
+     * lives outside them, in the `app/Console/Commands` directory Laravel ships
+     * with. Nested directories are dropped so a file is parsed once.
+     *
+     * @return list<string>
+     */
+    protected function classMapDirectories(): array
+    {
+        $candidates = [
+            base_path('app'),
+            base_path($this->layerDirectory('domain')),
+            base_path($this->layerDirectory('application')),
+            base_path($this->layerDirectory('infrastructure')),
+        ];
+
+        $candidates = array_values(array_unique(array_filter(
+            $candidates,
+            fn (string $directory): bool => $this->files->isDirectory($directory)
+        )));
+
+        usort($candidates, fn (string $a, string $b): int => strlen($a) <=> strlen($b));
+
+        $directories = [];
+
+        foreach ($candidates as $candidate) {
+            foreach ($directories as $kept) {
+                if (str_starts_with($candidate, rtrim($kept, '/') . '/')) {
+                    continue 2;
+                }
+            }
+
+            $directories[] = $candidate;
+        }
+
+        return $directories;
+    }
+}

--- a/src/Concerns/ParsesPhpSource.php
+++ b/src/Concerns/ParsesPhpSource.php
@@ -47,7 +47,15 @@ trait ParsesPhpSource
      */
     protected function extractUseStatements(string $contents): array
     {
-        $tokens     = token_get_all($contents);
+        return $this->extractUseStatementsFromTokens(token_get_all($contents));
+    }
+
+    /**
+     * @param  array<int, array{0: int, 1: string, 2: int}|string>  $tokens
+     * @return list<array{name: string, alias: string, line: int}>
+     */
+    protected function extractUseStatementsFromTokens(array $tokens): array
+    {
         $statements = [];
         $depth      = 0;
         $previous   = null;
@@ -93,82 +101,142 @@ trait ParsesPhpSource
     }
 
     /**
-     * Resolve the parent class and the interfaces of the types declared in a file.
+     * List the types declared in a file with their resolved parents.
      *
-     * @return array{extends: list<string>, implements: list<string>}
+     * Anonymous classes are skipped: they cannot be referenced, so they never
+     * take part in an inheritance chain we can follow.
+     *
+     * @return list<array{fqcn: string, kind: string, extends: list<string>, implements: list<string>}>
      */
-    protected function parseClassSignature(string $contents): array
+    protected function parseClassDeclarations(string $contents): array
     {
+        $kinds = [
+            T_CLASS     => 'class',
+            T_INTERFACE => 'interface',
+            T_TRAIT     => 'trait',
+            T_ENUM      => 'enum',
+        ];
+
+        $tokens  = token_get_all($contents);
         $imports = [];
 
-        foreach ($this->extractUseStatements($contents) as $statement) {
+        foreach ($this->extractUseStatementsFromTokens($tokens) as $statement) {
             $imports[strtolower($statement['alias'])] = $statement['name'];
         }
 
-        $tokens     = token_get_all($contents);
-        $namespace  = '';
-        $extends    = [];
-        $implements = [];
+        $namespace    = '';
+        $declarations = [];
+        $previous     = null;
 
         for ($i = 0, $count = count($tokens); $i < $count; $i++) {
             $token = $tokens[$i];
 
             if (! is_array($token)) {
+                $previous = $token;
+
+                continue;
+            }
+
+            if (in_array($token[0], $this->insignificantTokens, true)) {
                 continue;
             }
 
             if ($token[0] === T_NAMESPACE) {
                 [$declared, $i] = $this->readName($tokens, $i + 1);
                 $namespace      = trim($declared, '\\');
+                $previous       = null;
 
                 continue;
             }
 
-            if ($token[0] !== T_EXTENDS && $token[0] !== T_IMPLEMENTS) {
+            // `Foo::class` also yields a T_CLASS token, and `new class {}` has no name.
+            if (! isset($kinds[$token[0]]) || (is_array($previous) && $previous[0] === T_DOUBLE_COLON)) {
+                $previous = $token;
+
                 continue;
             }
 
-            $target = $token[0] === T_EXTENDS ? 'extends' : 'implements';
+            $kind       = $kinds[$token[0]];
+            [$name, $i] = $this->readName($tokens, $i + 1);
 
-            for ($j = $i + 1; $j < $count; $j++) {
-                $next = $tokens[$j];
+            if ($name === '') {
+                $previous = $token;
 
-                if (is_string($next)) {
-                    if ($next === ',') {
-                        continue;
-                    }
-
-                    break;
-                }
-
-                if (in_array($next[0], $this->insignificantTokens, true)) {
-                    continue;
-                }
-
-                if ($next[0] === T_IMPLEMENTS) {
-                    $target = 'implements';
-
-                    continue;
-                }
-
-                if (! in_array($next[0], $this->nameTokens, true)) {
-                    break;
-                }
-
-                [$name, $j] = $this->readName($tokens, $j);
-                $resolved   = $this->resolveName($name, $namespace, $imports);
-
-                if ($target === 'extends') {
-                    $extends[] = $resolved;
-                } else {
-                    $implements[] = $resolved;
-                }
+                continue;
             }
 
-            $i = $j;
+            $declarations[] = $this->readTypeParents($tokens, $i + 1, $namespace, $imports, $name, $kind);
+            $previous       = null;
         }
 
-        return ['extends' => $extends, 'implements' => $implements];
+        return $declarations;
+    }
+
+    /**
+     * Read the `extends` and `implements` clauses following a type name.
+     *
+     * @param  array<int, array{0: int, 1: string, 2: int}|string>  $tokens
+     * @param  array<string, string>  $imports
+     * @return array{fqcn: string, kind: string, extends: list<string>, implements: list<string>}
+     */
+    protected function readTypeParents(array $tokens, int $index, string $namespace, array $imports, string $name, string $kind): array
+    {
+        $extends    = [];
+        $implements = [];
+        $target     = null;
+
+        for ($i = $index, $count = count($tokens); $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if (is_string($token)) {
+                if ($token === '{') {
+                    break;
+                }
+
+                continue;
+            }
+
+            if (in_array($token[0], $this->insignificantTokens, true)) {
+                continue;
+            }
+
+            if ($token[0] === T_EXTENDS) {
+                $target = 'extends';
+
+                continue;
+            }
+
+            if ($token[0] === T_IMPLEMENTS) {
+                $target = 'implements';
+
+                continue;
+            }
+
+            // Anything before the first clause, such as an enum backing type.
+            if ($target === null) {
+                continue;
+            }
+
+            if (! in_array($token[0], $this->nameTokens, true)) {
+                break;
+            }
+
+            [$parent, $i] = $this->readName($tokens, $i);
+            $resolved     = $this->resolveName($parent, $namespace, $imports);
+
+            if ($target === 'extends') {
+                $extends[] = $resolved;
+            } else {
+                $implements[] = $resolved;
+            }
+        }
+
+        return [
+            'fqcn'       => $namespace !== '' ? $namespace . '\\' . $name : $name,
+            'kind'       => $kind,
+            'extends'    => $extends,
+            'implements' => $implements,
+        ];
     }
 
     /**

--- a/tests/Unit/Commands/ValidateCommandTest.php
+++ b/tests/Unit/Commands/ValidateCommandTest.php
@@ -34,6 +34,7 @@ describe('ValidateArchitectureCommand', function () {
     afterEach(function () {
         $this->filesystem->deleteDirectory(base_path('app/Infrastructure'));
         $this->filesystem->deleteDirectory(base_path('app/Domain'));
+        $this->filesystem->deleteDirectory(base_path('app/Console/Commands'));
     });
 
     it('has correct command signature', function () {
@@ -147,6 +148,163 @@ describe('ValidateArchitectureCommand', function () {
         );
 
         expect($this->command->checkConsoleCommandViolations('app/Infrastructure'))->toBe([$path]);
+    });
+
+    it('reports a command extending a project base class', function () {
+        $base = writeAppFile(
+            'app/Infrastructure/Console/Commands/BaseCommand.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Console\Commands;
+
+            use Illuminate\Console\Command;
+
+            abstract class BaseCommand extends Command {}
+            PHP
+        );
+
+        $child = writeAppFile(
+            'app/Infrastructure/Console/Commands/SyncPractices.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Console\Commands;
+
+            class SyncPractices extends BaseCommand {}
+            PHP
+        );
+
+        expect($this->command->checkConsoleCommandViolations('app/Infrastructure'))
+            ->toBe(collect([$base, $child])->sort()->values()->all());
+    });
+
+    it('follows a base class living outside the three layers', function () {
+        writeAppFile(
+            'app/Console/Commands/BaseCommand.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Console\Commands;
+
+            use Illuminate\Console\Command;
+
+            abstract class BaseCommand extends Command {}
+            PHP
+        );
+
+        $child = writeAppFile(
+            'app/Infrastructure/Console/Commands/SyncPractices.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Console\Commands;
+
+            use App\Console\Commands\BaseCommand;
+
+            class SyncPractices extends BaseCommand {}
+            PHP
+        );
+
+        expect($this->command->checkConsoleCommandViolations('app/Infrastructure'))->toBe([$child]);
+    });
+
+    it('does not report a command whose parent lives in vendor', function () {
+        writeAppFile(
+            'app/Infrastructure/Console/Commands/PublishAssets.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Console\Commands;
+
+            class PublishAssets extends \Vendor\Package\Console\AssetCommand {}
+            PHP
+        );
+
+        expect($this->command->checkConsoleCommandViolations('app/Infrastructure'))->toBeEmpty();
+    });
+
+    it('does not loop on a circular inheritance chain', function () {
+        writeAppFile(
+            'app/Infrastructure/Console/Commands/Ping.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Console\Commands;
+
+            class Ping extends Pong {}
+            PHP
+        );
+
+        writeAppFile(
+            'app/Infrastructure/Console/Commands/Pong.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Console\Commands;
+
+            class Pong extends Ping {}
+            PHP
+        );
+
+        expect($this->command->checkConsoleCommandViolations('app/Infrastructure'))->toBeEmpty();
+    });
+
+    it('reports a job extending an abstract base job', function () {
+        $base = writeAppFile(
+            'app/Infrastructure/Jobs/BaseJob.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Jobs;
+
+            use Illuminate\Contracts\Queue\ShouldQueue;
+
+            abstract class BaseJob implements ShouldQueue {}
+            PHP
+        );
+
+        $child = writeAppFile(
+            'app/Infrastructure/Jobs/SendReport.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Jobs;
+
+            class SendReport extends BaseJob {}
+            PHP
+        );
+
+        expect($this->command->checkQueuedJobViolations('app/Infrastructure'))
+            ->toBe(collect([$base, $child])->sort()->values()->all());
+    });
+
+    it('reports a class implementing an interface that extends ShouldQueue', function () {
+        writeAppFile(
+            'app/Infrastructure/Jobs/Queueable.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Jobs;
+
+            use Illuminate\Contracts\Queue\ShouldQueue;
+
+            interface Queueable extends ShouldQueue {}
+            PHP
+        );
+
+        $path = writeAppFile(
+            'app/Infrastructure/Jobs/SendInvoice.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Infrastructure\Jobs;
+
+            class SendInvoice implements Queueable {}
+            PHP
+        );
+
+        expect($this->command->checkQueuedJobViolations('app/Infrastructure'))->toBe([$path]);
     });
 
     it('does not report a business class whose name merely contains Job', function () {


### PR DESCRIPTION
Console commands, queued jobs and observers are now detected from the class inheritance chain parsed from source, not from file names. A CommandPaletteController or JobApplicationResource is no longer reported, while a command extending a project BaseCommand (even outside the three layers, e.g. app/Console/Commands/BaseCommand.php) still is.

The class map is built once per invocation by tokenising every file under app/. Inheritance chains stop at parents not declared under app/ (i.e. in vendor/), so classes extending third-party base classes are not reported. Circular chains are guarded with a visited set.