### PR TITLE
fix(make-domain): generated actions and requests are not valid php

### DIFF
--- a/src/Commands/MakeDomainCommand.php
+++ b/src/Commands/MakeDomainCommand.php
@@ -137,8 +137,8 @@ class MakeDomainCommand extends Command
         foreach ($actions as $action => $requestClass) {
             $stub    = $this->getStub('action');
             $content = $this->replacePlaceholders($stub, $name, [
-                'ActionName'  => $action . $name . 'Action',
-                'RequestName' => $requestClass ?: 'Request',
+                '{{ActionName}}'  => $action . $name . 'Action',
+                '{{RequestName}}' => $requestClass ?: 'Request',
             ]);
 
             $this->files->put("{$actionsPath}/{$action}{$name}Action.php", $content);
@@ -188,7 +188,7 @@ class MakeDomainCommand extends Command
         foreach ($requests as $request) {
             $stub    = $this->getStub('request');
             $content = $this->replacePlaceholders($stub, $name, [
-                'RequestName' => $request . $name . 'Request',
+                '{{RequestName}}' => $request . $name . 'Request',
             ]);
 
             $this->files->put("{$requestsPath}/{$request}{$name}Request.php", $content);

--- a/tests/Feature/CommandIntegrationTest.php
+++ b/tests/Feature/CommandIntegrationTest.php
@@ -236,4 +236,53 @@ describe('Command Integration', function () {
         expect(File::exists(app_path('Infrastructure/Notifications/OrderNotification.php')))->toBeTrue();
         expect(File::exists(app_path('Infrastructure/Exports/OrderExport.php')))->toBeTrue();
     });
+
+    it('generates action and request classes without leftover placeholders', function () {
+        $this->artisan('clean-arch:install');
+
+        $this->artisan('clean-arch:make-domain', ['name' => 'Invoice'])
+            ->expectsConfirmation('Would you like to generate an Observer?', 'no')
+            ->expectsConfirmation('Would you like to generate a Listener?', 'no')
+            ->expectsConfirmation('Would you like to generate a Job?', 'no')
+            ->expectsConfirmation('Would you like to generate a Mail?', 'no')
+            ->expectsConfirmation('Would you like to generate a Notification?', 'no')
+            ->expectsConfirmation('Would you like to generate an Export?', 'no')
+            ->assertExitCode(0);
+
+        $action = File::get(app_path('Application/Actions/Invoices/CreateInvoiceAction.php'));
+        expect($action)->toContain('class CreateInvoiceAction');
+        expect($action)->not->toContain('{{');
+
+        $request = File::get(app_path('Infrastructure/Http/Requests/CreateInvoiceRequest.php'));
+        expect($request)->toContain('class CreateInvoiceRequest');
+        expect($request)->not->toContain('{{');
+    });
+
+    it('generates every domain file as valid php', function () {
+        $this->artisan('clean-arch:install');
+
+        $this->artisan('clean-arch:make-domain', ['name' => 'Receipt'])
+            ->expectsConfirmation('Would you like to generate an Observer?', 'no')
+            ->expectsConfirmation('Would you like to generate a Listener?', 'no')
+            ->expectsConfirmation('Would you like to generate a Job?', 'no')
+            ->expectsConfirmation('Would you like to generate a Mail?', 'no')
+            ->expectsConfirmation('Would you like to generate a Notification?', 'no')
+            ->expectsConfirmation('Would you like to generate an Export?', 'no')
+            ->assertExitCode(0);
+
+        $files = [
+            app_path('Domain/Receipts/Models/Receipt.php'),
+            app_path('Application/Actions/Receipts/CreateReceiptAction.php'),
+            app_path('Application/Actions/Receipts/GetByIdReceiptAction.php'),
+            app_path('Application/Services/ReceiptService.php'),
+            app_path('Infrastructure/Http/Requests/CreateReceiptRequest.php'),
+            app_path('Infrastructure/Http/Requests/UpdateReceiptRequest.php'),
+            app_path('Infrastructure/Http/Controllers/Api/ReceiptsController.php'),
+        ];
+
+        foreach ($files as $file) {
+            expect(File::exists($file))->toBeTrue();
+            expect(token_get_all(File::get($file), TOKEN_PARSE))->toBeArray();
+        }
+    });
 });


### PR DESCRIPTION
## The bug

`clean-arch:make-domain` generates action and request classes that are not valid PHP.

`MakeDomainCommand::replacePlaceholders()` uses the array keys verbatim in `str_replace()`. Two call sites passed the placeholder name without its braces:

```php
'ActionName'  => $action . $name . 'Action',
'RequestName' => $request . $name . 'Request',
```

`str_replace('ActionName', 'CreateUserAction', 'class {{ActionName}} extends BaseAction')` replaces the inner substring and leaves the braces behind:

```php
class {{CreateUserAction}} extends BaseAction
class {{CreateUserRequest}} extends BaseRequest
```

Every `Create*Action.php`, `Update*Action.php`, `Delete*Action.php`, `GetById*Action.php`, `Create*Request.php` and `Update*Request.php` produced by `make-domain` is affected. The files are written, the command exits 0, and the failure only shows up when the application autoloads them.

## The fix

Three keys now carry their braces, matching every other replacement in the class:

```php
'{{ActionName}}'  => $action . $name . 'Action',
'{{RequestName}}' => $requestClass ?: 'Request',
'{{RequestName}}' => $request . $name . 'Request',
```

## Why it was not caught

The existing tests mock the filesystem and assert that `put()` was called, never what was written. The integration tests assert that files exist, never that they parse.

Two tests are added on the real filesystem. The first asserts the generated action and request contain their class declaration and no leftover `{{`. The second runs `token_get_all(..., TOKEN_PARSE)` over every file a domain generates, so any future stub or placeholder regression fails as a parse error rather than silently shipping.

Both tests fail on the current `main` (the second with a `ParseError`) and pass with the fix.

## Scope

This PR targets `main` and touches nothing else. It is independent of the open stack and should go in first: the bug affects anyone running `make-domain` today.
