### PR TITLE
fix(ci): repair the CI workflow and stop duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,35 +4,37 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main, develop ]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  tests:
-    uses: ./.github/workflows/tests.yml
-
-  # code-style:
-  #   uses: ./.github/workflows/code-style.yml
-  
-  code-style-fix:
-    uses: ./.github/workflows/code-style-fix.yml
+  code-style:
+    uses: ./.github/workflows/code-style.yml
 
   static-analysis:
     uses: ./.github/workflows/static-analysis.yml
 
+  tests:
+    uses: ./.github/workflows/tests.yml
+
   quality-gate:
     runs-on: ubuntu-latest
-    needs: [tests, code-style-fix, static-analysis]
+    name: Quality gate
+    needs: [ code-style, static-analysis, tests ]
     if: always()
-    
+
     steps:
       - name: Check quality gate
         run: |
-          if [ "${{ needs.tests.result }}" != "success" ] || [ "${{ needs.code-style.result }}" != "success" ] || [ "${{ needs.static-analysis.result }}" != "success" ]; then
-            echo "❌ Quality gate failed!"
-            echo "Tests: ${{ needs.tests.result }}"
-            echo "Code Style: ${{ needs.code-style.result }}"
-            echo "Static Analysis: ${{ needs.static-analysis.result }}"
+          echo "Code Style: ${{ needs.code-style.result }}"
+          echo "Static Analysis: ${{ needs.static-analysis.result }}"
+          echo "Tests: ${{ needs.tests.result }}"
+
+          if [ "${{ needs.code-style.result }}" != "success" ] || [ "${{ needs.static-analysis.result }}" != "success" ] || [ "${{ needs.tests.result }}" != "success" ]; then
+            echo "Quality gate failed."
             exit 1
-          else
-            echo "✅ Quality gate passed!"
-          fi 
+          fi
+
+          echo "Quality gate passed."

--- a/.github/workflows/code-style-fix.yml
+++ b/.github/workflows/code-style-fix.yml
@@ -1,10 +1,10 @@
 name: Code Style (Auto-fix)
 
+# Not part of the quality gate and never triggered automatically: this workflow
+# rewrites files and pushes a commit, so it must never race the code-style check
+# that guards pull requests. Run it by hand from the Actions tab when needed.
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -1,10 +1,7 @@
 name: Code Style
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  workflow_call:
 
 jobs:
   pint:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,10 +1,7 @@
 name: Static Analysis
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  workflow_call:
 
 jobs:
   phpstan:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,7 @@
 name: Tests
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  workflow_call:
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 A Laravel package to easily implement Clean Architecture in your projects. 🚀
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/plin-code/laravel-clean-architecture.svg?style=flat-square)](https://packagist.org/packages/plin-code/laravel-clean-architecture)
-[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/plin-code/laravel-clean-architecture/tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/plin-code/laravel-clean-architecture/actions?query=workflow%3ATests+branch%3Amain)
-[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/plin-code/laravel-clean-architecture/code-style-fix.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/plin-code/laravel-clean-architecture/actions?query=workflow%3A%22Code+Style+%28Auto-fix%29%22+branch%3Amain)
+[![CI](https://img.shields.io/github/actions/workflow/status/plin-code/laravel-clean-architecture/ci.yml?branch=main&label=ci&style=flat-square)](https://github.com/plin-code/laravel-clean-architecture/actions/workflows/ci.yml?query=branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/plin-code/laravel-clean-architecture.svg?style=flat-square)](https://packagist.org/packages/plin-code/laravel-clean-architecture)
 
 ## ✨ Features


### PR DESCRIPTION
## The problem

`ci.yml` has never run. Every attempt since 2026-03-31 fails before any job starts, including pushes to `main`, which is why the logs are empty and GitHub only reports "this run likely failed because of a workflow file issue".

Two independent defects, both in the file itself.

**It calls workflows that are not callable.** `uses: ./.github/workflows/tests.yml` requires the called workflow to declare `on: workflow_call`. None of `tests.yml`, `code-style.yml`, `static-analysis.yml` or `code-style-fix.yml` did. This alone makes the workflow file invalid.

**The quality gate reads a job it does not depend on.** `needs` listed `code-style-fix`, while the shell script tested `needs.code-style.result`. `code-style` was the commented out job right above.

A third problem was hiding behind those: `pull_request: branches: [ main, develop ]` filters on the **target** branch, so a pull request opened against a feature branch got no checks at all. Stacked pull requests were merging with zero CI.

## The fix

`ci.yml` becomes the single entry point. It keeps `push` on `main` and `develop`, and takes `pull_request` with no branch filter so stacked pull requests are covered. The gate now depends on, and reads, the same three jobs.

`tests.yml`, `code-style.yml` and `static-analysis.yml` become `on: workflow_call` only. This is what prevents double runs: a workflow that keeps its own `push` and `pull_request` triggers while also being called would execute twice for every event. Exactly one workflow in the repository now reacts to an automatic event.

`code-style-fix.yml` leaves the pipeline entirely. It runs Pint in fix mode and pushes a commit through `git-auto-commit-action`; running it alongside the `code-style` check means one job rewrites the code while another checks it. It is now `workflow_dispatch` only, so it can still be run by hand from the Actions tab.

`concurrency` with `cancel-in-progress` is added, so two pushes on the same ref no longer leave two live runs.

## What this changes for you

**Check names change.** A called workflow's jobs are nested under the caller, so `PHPStan` becomes `static-analysis / PHPStan`, `Laravel Pint` becomes `code-style / Laravel Pint`, and `P8.3 - L12.* - prefer-stable` becomes `tests / P8.3 - L12.* - prefer-stable`. Any branch protection rule listing the old names must be updated, otherwise it will wait forever for checks that no longer exist. `Quality gate` is the single check worth requiring.

**Badges.** A `workflow_call` only workflow produces no runs of its own, so the badges pointing at `tests.yml` and `code-style-fix.yml` would stop resolving. Both are replaced by one badge on `ci.yml`. One orchestrator means one badge.
