### PR TITLE
refactor(commands): remove duplicated stub helpers

### DIFF
--- a/src/Commands/GeneratePackageCommand.php
+++ b/src/Commands/GeneratePackageCommand.php
@@ -5,9 +5,12 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use PlinCode\LaravelCleanArchitecture\Concerns\RendersStubs;
 
 class GeneratePackageCommand extends Command
 {
+    use RendersStubs;
+
     protected $signature = 'clean-arch:generate-package {name : The name of the package}
                           {vendor : The vendor name}
                           {--path= : Custom path for the package}
@@ -175,16 +178,5 @@ class GeneratePackageCommand extends Command
 
         $this->files->put("{$path}/README.md", $content);
         $this->info('Created: README.md');
-    }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
     }
 }

--- a/src/Commands/InstallCleanArchitectureCommand.php
+++ b/src/Commands/InstallCleanArchitectureCommand.php
@@ -4,10 +4,12 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use PlinCode\LaravelCleanArchitecture\Concerns\RendersStubs;
 use PlinCode\LaravelCleanArchitecture\Concerns\ResolvesArchitectureDirectories;
 
 class InstallCleanArchitectureCommand extends Command
 {
+    use RendersStubs;
     use ResolvesArchitectureDirectories;
 
     protected $signature = 'clean-arch:install
@@ -201,16 +203,5 @@ class InstallCleanArchitectureCommand extends Command
         $stub = $this->getStub('readme');
         $this->files->put(base_path('CLEAN_ARCHITECTURE.md'), $stub);
         $this->info('Created: CLEAN_ARCHITECTURE.md');
-    }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
     }
 }

--- a/src/Commands/MakeActionCommand.php
+++ b/src/Commands/MakeActionCommand.php
@@ -73,15 +73,4 @@ class MakeActionCommand extends Command
 
         return str_replace(array_keys(array_merge($replacements, $extra)), array_values(array_merge($replacements, $extra)), $content);
     }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
-    }
 }

--- a/src/Commands/MakeControllerCommand.php
+++ b/src/Commands/MakeControllerCommand.php
@@ -5,9 +5,12 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use PlinCode\LaravelCleanArchitecture\Concerns\RendersStubs;
 
 class MakeControllerCommand extends Command
 {
+    use RendersStubs;
+
     protected $signature = 'clean-arch:make-controller {name : The name of the controller}
                           {--api : Generate API controller}
                           {--web : Generate Web controller}
@@ -90,16 +93,5 @@ class MakeControllerCommand extends Command
         ];
 
         return str_replace(array_keys($replacements), array_values($replacements), $content);
-    }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
     }
 }

--- a/src/Commands/MakeDomainCommand.php
+++ b/src/Commands/MakeDomainCommand.php
@@ -378,15 +378,4 @@ class MakeDomainCommand extends Command
     {
         return Str::snake(Str::plural($name));
     }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
-    }
 }

--- a/src/Commands/MakeExportCommand.php
+++ b/src/Commands/MakeExportCommand.php
@@ -4,10 +4,12 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
+use PlinCode\LaravelCleanArchitecture\Concerns\RendersStubs;
 
 class MakeExportCommand extends Command
 {
+    use RendersStubs;
+
     protected $signature = 'clean-arch:make-export {name : The name of the export}
                           {--force : Overwrite existing files}';
 
@@ -35,7 +37,7 @@ class MakeExportCommand extends Command
     protected function createExport(string $name): void
     {
         $stub    = $this->getStub('export');
-        $content = $this->replacePlaceholders($stub, $name);
+        $content = $this->replaceDomainPlaceholders($stub, $name);
 
         $exportPath = app_path('Infrastructure/Exports');
 
@@ -45,28 +47,5 @@ class MakeExportCommand extends Command
 
         $this->files->put("{$exportPath}/{$name}Export.php", $content);
         $this->info("Created: Infrastructure/Exports/{$name}Export.php");
-    }
-
-    protected function replacePlaceholders(string $content, string $name): string
-    {
-        $pluralName     = Str::plural($name);
-        $domainVariable = Str::camel($name);
-
-        return str_replace(
-            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
-            [$name, $pluralName, $domainVariable],
-            $content
-        );
-    }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
     }
 }

--- a/src/Commands/MakeJobCommand.php
+++ b/src/Commands/MakeJobCommand.php
@@ -4,10 +4,12 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
+use PlinCode\LaravelCleanArchitecture\Concerns\RendersStubs;
 
 class MakeJobCommand extends Command
 {
+    use RendersStubs;
+
     protected $signature = 'clean-arch:make-job {name : The name of the job}
                           {--force : Overwrite existing files}';
 
@@ -35,7 +37,7 @@ class MakeJobCommand extends Command
     protected function createJob(string $name): void
     {
         $stub    = $this->getStub('job');
-        $content = $this->replacePlaceholders($stub, $name);
+        $content = $this->replaceDomainPlaceholders($stub, $name);
 
         $jobPath = app_path('Application/Jobs');
 
@@ -45,28 +47,5 @@ class MakeJobCommand extends Command
 
         $this->files->put("{$jobPath}/{$name}Job.php", $content);
         $this->info("Created: Application/Jobs/{$name}Job.php");
-    }
-
-    protected function replacePlaceholders(string $content, string $name): string
-    {
-        $pluralName     = Str::plural($name);
-        $domainVariable = Str::camel($name);
-
-        return str_replace(
-            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
-            [$name, $pluralName, $domainVariable],
-            $content
-        );
-    }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
     }
 }

--- a/src/Commands/MakeListenerCommand.php
+++ b/src/Commands/MakeListenerCommand.php
@@ -4,10 +4,12 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
+use PlinCode\LaravelCleanArchitecture\Concerns\RendersStubs;
 
 class MakeListenerCommand extends Command
 {
+    use RendersStubs;
+
     protected $signature = 'clean-arch:make-listener {name : The name of the listener}
                           {--force : Overwrite existing files}';
 
@@ -35,7 +37,7 @@ class MakeListenerCommand extends Command
     protected function createListener(string $name): void
     {
         $stub    = $this->getStub('listener');
-        $content = $this->replacePlaceholders($stub, $name);
+        $content = $this->replaceDomainPlaceholders($stub, $name);
 
         $listenerPath = app_path('Application/Listeners');
 
@@ -45,28 +47,5 @@ class MakeListenerCommand extends Command
 
         $this->files->put("{$listenerPath}/{$name}Listener.php", $content);
         $this->info("Created: Application/Listeners/{$name}Listener.php");
-    }
-
-    protected function replacePlaceholders(string $content, string $name): string
-    {
-        $pluralName     = Str::plural($name);
-        $domainVariable = Str::camel($name);
-
-        return str_replace(
-            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
-            [$name, $pluralName, $domainVariable],
-            $content
-        );
-    }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
     }
 }

--- a/src/Commands/MakeMailCommand.php
+++ b/src/Commands/MakeMailCommand.php
@@ -4,10 +4,12 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
+use PlinCode\LaravelCleanArchitecture\Concerns\RendersStubs;
 
 class MakeMailCommand extends Command
 {
+    use RendersStubs;
+
     protected $signature = 'clean-arch:make-mail {name : The name of the mailable}
                           {--force : Overwrite existing files}';
 
@@ -35,7 +37,7 @@ class MakeMailCommand extends Command
     protected function createMail(string $name): void
     {
         $stub    = $this->getStub('mail');
-        $content = $this->replacePlaceholders($stub, $name);
+        $content = $this->replaceDomainPlaceholders($stub, $name);
 
         $mailPath = app_path('Infrastructure/Mail');
 
@@ -45,28 +47,5 @@ class MakeMailCommand extends Command
 
         $this->files->put("{$mailPath}/{$name}Mail.php", $content);
         $this->info("Created: Infrastructure/Mail/{$name}Mail.php");
-    }
-
-    protected function replacePlaceholders(string $content, string $name): string
-    {
-        $pluralName     = Str::plural($name);
-        $domainVariable = Str::camel($name);
-
-        return str_replace(
-            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
-            [$name, $pluralName, $domainVariable],
-            $content
-        );
-    }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
     }
 }

--- a/src/Commands/MakeNotificationCommand.php
+++ b/src/Commands/MakeNotificationCommand.php
@@ -4,10 +4,12 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
+use PlinCode\LaravelCleanArchitecture\Concerns\RendersStubs;
 
 class MakeNotificationCommand extends Command
 {
+    use RendersStubs;
+
     protected $signature = 'clean-arch:make-notification {name : The name of the notification}
                           {--force : Overwrite existing files}';
 
@@ -35,7 +37,7 @@ class MakeNotificationCommand extends Command
     protected function createNotification(string $name): void
     {
         $stub    = $this->getStub('notification');
-        $content = $this->replacePlaceholders($stub, $name);
+        $content = $this->replaceDomainPlaceholders($stub, $name);
 
         $notificationPath = app_path('Infrastructure/Notifications');
 
@@ -45,28 +47,5 @@ class MakeNotificationCommand extends Command
 
         $this->files->put("{$notificationPath}/{$name}Notification.php", $content);
         $this->info("Created: Infrastructure/Notifications/{$name}Notification.php");
-    }
-
-    protected function replacePlaceholders(string $content, string $name): string
-    {
-        $pluralName     = Str::plural($name);
-        $domainVariable = Str::camel($name);
-
-        return str_replace(
-            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
-            [$name, $pluralName, $domainVariable],
-            $content
-        );
-    }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
     }
 }

--- a/src/Commands/MakeObserverCommand.php
+++ b/src/Commands/MakeObserverCommand.php
@@ -5,9 +5,12 @@ namespace PlinCode\LaravelCleanArchitecture\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
+use PlinCode\LaravelCleanArchitecture\Concerns\RendersStubs;
 
 class MakeObserverCommand extends Command
 {
+    use RendersStubs;
+
     protected $signature = 'clean-arch:make-observer {name : The name of the observer}
                           {domain : The domain name}
                           {--force : Overwrite existing files}';
@@ -60,16 +63,5 @@ class MakeObserverCommand extends Command
             [$domain, $pluralDomain, $domainVariable],
             $content
         );
-    }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
     }
 }

--- a/src/Commands/MakeServiceCommand.php
+++ b/src/Commands/MakeServiceCommand.php
@@ -67,15 +67,4 @@ class MakeServiceCommand extends Command
 
         return str_replace(array_keys($replacements), array_values($replacements), $content);
     }
-
-    protected function getStub(string $stub): string
-    {
-        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
-
-        if (! $this->files->exists($stubPath)) {
-            throw new \Exception("Stub file not found: {$stubPath}");
-        }
-
-        return $this->files->get($stubPath);
-    }
 }

--- a/src/Concerns/RendersStubs.php
+++ b/src/Concerns/RendersStubs.php
@@ -2,8 +2,12 @@
 
 namespace PlinCode\LaravelCleanArchitecture\Concerns;
 
+use Illuminate\Support\Str;
+
 /**
  * Helpers shared by commands that render stubs before writing files.
+ *
+ * The using class must expose a `$files` Filesystem property.
  *
  * The package ships stubs with optional regions delimited by comment
  * markers, `// {{#name}}` and `// {{/name}}`. A command can keep or drop a
@@ -12,6 +16,34 @@ namespace PlinCode\LaravelCleanArchitecture\Concerns;
  */
 trait RendersStubs
 {
+    /**
+     * Read a stub shipped with the package.
+     *
+     * @throws \Exception when the stub does not exist.
+     */
+    protected function getStub(string $stub): string
+    {
+        $stubPath = __DIR__ . "/../../stubs/{$stub}.stub";
+
+        if (! $this->files->exists($stubPath)) {
+            throw new \Exception("Stub file not found: {$stubPath}");
+        }
+
+        return $this->files->get($stubPath);
+    }
+
+    /**
+     * Apply the placeholders every domain oriented stub shares.
+     */
+    protected function replaceDomainPlaceholders(string $content, string $name): string
+    {
+        return str_replace(
+            ['{{DomainName}}', '{{PluralDomainName}}', '{{domainVariable}}'],
+            [$name, Str::plural($name), Str::camel($name)],
+            $content
+        );
+    }
+
     /**
      * Keep or drop a named block delimited by `// {{#name}}` / `// {{/name}}` markers.
      *

--- a/tests/Unit/Commands/MakeExportCommandTest.php
+++ b/tests/Unit/Commands/MakeExportCommandTest.php
@@ -47,7 +47,7 @@ describe('MakeExportCommand', function () {
 
     it('replaces placeholders correctly', function () {
         $reflection = new ReflectionClass($this->command);
-        $method     = $reflection->getMethod('replacePlaceholders');
+        $method     = $reflection->getMethod('replaceDomainPlaceholders');
         $method->setAccessible(true);
 
         $content = '{{DomainName}} {{PluralDomainName}} {{domainVariable}}';

--- a/tests/Unit/Commands/MakeJobCommandTest.php
+++ b/tests/Unit/Commands/MakeJobCommandTest.php
@@ -47,7 +47,7 @@ describe('MakeJobCommand', function () {
 
     it('replaces placeholders correctly', function () {
         $reflection = new ReflectionClass($this->command);
-        $method     = $reflection->getMethod('replacePlaceholders');
+        $method     = $reflection->getMethod('replaceDomainPlaceholders');
         $method->setAccessible(true);
 
         $content = '{{DomainName}} {{PluralDomainName}} {{domainVariable}}';

--- a/tests/Unit/Commands/MakeListenerCommandTest.php
+++ b/tests/Unit/Commands/MakeListenerCommandTest.php
@@ -47,7 +47,7 @@ describe('MakeListenerCommand', function () {
 
     it('replaces placeholders correctly', function () {
         $reflection = new ReflectionClass($this->command);
-        $method     = $reflection->getMethod('replacePlaceholders');
+        $method     = $reflection->getMethod('replaceDomainPlaceholders');
         $method->setAccessible(true);
 
         $content = '{{DomainName}} {{PluralDomainName}} {{domainVariable}}';

--- a/tests/Unit/Commands/MakeMailCommandTest.php
+++ b/tests/Unit/Commands/MakeMailCommandTest.php
@@ -47,7 +47,7 @@ describe('MakeMailCommand', function () {
 
     it('replaces placeholders correctly', function () {
         $reflection = new ReflectionClass($this->command);
-        $method     = $reflection->getMethod('replacePlaceholders');
+        $method     = $reflection->getMethod('replaceDomainPlaceholders');
         $method->setAccessible(true);
 
         $content = '{{DomainName}} {{PluralDomainName}} {{domainVariable}}';

--- a/tests/Unit/Commands/MakeNotificationCommandTest.php
+++ b/tests/Unit/Commands/MakeNotificationCommandTest.php
@@ -47,7 +47,7 @@ describe('MakeNotificationCommand', function () {
 
     it('replaces placeholders correctly', function () {
         $reflection = new ReflectionClass($this->command);
-        $method     = $reflection->getMethod('replacePlaceholders');
+        $method     = $reflection->getMethod('replaceDomainPlaceholders');
         $method->setAccessible(true);
 
         $content = '{{DomainName}} {{PluralDomainName}} {{domainVariable}}';

--- a/tests/Unit/StubsTest.php
+++ b/tests/Unit/StubsTest.php
@@ -154,6 +154,13 @@ describe('Stub Files', function () {
             ->toContain("'extend_base_classes' => true");
     });
 
+    it('keeps the shipped config and the install stub in sync', function () {
+        $shipped = require __DIR__ . '/../../config/clean-architecture.php';
+        $stub    = require $this->stubsPath . '/config.stub';
+
+        expect($stub)->toEqual($shipped);
+    });
+
     it('shipped config declares extend_base_classes', function () {
         $config = file_get_contents($this->stubsPath . '/../config/clean-architecture.php');
 


### PR DESCRIPTION
## What this removes

`getStub()` was byte identical in twelve command classes. Same MD5 for all of them, roughly ten lines each. It now lives in the `RendersStubs` trait, which three commands already used.

`replacePlaceholders()` was byte identical in five commands (export, job, listener, mail, notification): the same three domain placeholders, no specialisation. It moves to the trait as `replaceDomainPlaceholders()`. The other five commands keep their own `replacePlaceholders()`, because each adds placeholders of its own and those are specialisation, not duplication. The trait method has a distinct name on purpose, so nothing silently overrides anything.

Net effect: 207 lines deleted, 75 added.

`ValidateArchitectureCommand` does not use the trait. It renders no stubs.

## What this guards

`config/clean-architecture.php` and `stubs/config.stub` must hold the same configuration: one is published by the service provider, the other is written by `clean-arch:install`. They were kept in sync by hand and nothing checked it, so they had already drifted once during recent work.

A test now requires both files and compares the resulting arrays. Verified that it fails when the two diverge: changing a single directory value in the stub turns the test red.

## Note on the trait

`RendersStubs::getStub()` reads `$this->files`, so the using class must expose a `Filesystem` property. That requirement is now stated in the trait docblock. It is a real coupling and worth being explicit about rather than leaving it to be discovered.

## Verification

`composer format`, `composer analyse` and `composer test` all pass. 202 tests, one more than before, which is the new sync test.
