### PR TITLE
docs(changelog): add 2.0.2 and 2.1.0 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to `laravel-clean-architecture` will be documented in this file.
 
+## [2.1.0] - 2026-08-28
+
+### Fixed
+
+- `make-domain` generated actions and requests that were not valid PHP. The placeholder keys were passed to `str_replace()` without their braces, so `class {{ActionName}}` became `class {{CreateUserAction}}` instead of `class CreateUserAction`. Every `Create*Action`, `Update*Action`, `Delete*Action`, `GetById*Action`, `Create*Request` and `Update*Request` produced by the command was affected
+- `clean-arch:validate` reported controllers, resources and requests as violations when their name merely contained `Command`, `Job` or `Observer`. A `CommandPaletteController` is no longer a console command. Detection is now based on the class (`extends Illuminate\Console\Command`, `implements ShouldQueue`) rather than on the file name, and observers match the exact `Observer.php` suffix
+- `clean-arch:validate` counted trait `use` statements inside a class body, commented out lines and occurrences inside strings as namespace imports. Imports are now extracted with `token_get_all()`, including grouped and aliased ones
+- `directories` in the configuration file was never read. Changing `directories.domain` produced no effect and no error. It is now honoured by `clean-arch:validate` and `clean-arch:install`, with the previous hardcoded values as defaults when the config is not published. Layer namespaces are derived from the same values
+- The CI workflow had been failing since March: it called workflows that did not declare `on: workflow_call`, and its quality gate read a job that was not among its dependencies. Pull requests opened against a branch other than `main` or `develop` received no checks at all
+
+### Added
+
+- `validation.rules` lets each rule of `clean-arch:validate` be turned off by name. Every rule stays enabled by default, so behaviour does not change on upgrade. `no_commands_in_infrastructure` is the likely candidate for opting out: a console command is an input adapter like an HTTP controller, and keeping it in `Application` forces that layer to depend on `Illuminate\Console`
+- `validation.custom_messages` controls whether generated form requests carry a `messages()` method with hardcoded English strings. Useful for projects that rely on Laravel translations
+- `generation.extend_base_classes` and the `--no-base` flag on `make-domain`, `make-service` and `make-action` generate services and actions without extending `BaseService` and `BaseAction`. The flag wins over the config
+
+### Changed
+
+- `getStub()` and the shared placeholder replacement move from the individual commands into the `RendersStubs` trait. In `make-export`, `make-job`, `make-listener`, `make-mail` and `make-notification` the shared method is now called `replaceDomainPlaceholders()`, which matters only if you subclassed one of them and overrode `replacePlaceholders()`
+- The README no longer claims the Domain layer is free of frameworks. Generated models extend `App\Domain\Shared\BaseModel`, which extends `Illuminate\Database\Eloquent\Model`, and the trade-off is now stated explicitly
+- The generated `CLEAN_ARCHITECTURE.md` describes the directories `clean-arch:install` actually creates: `Console/Commands`, plus `Exports` and `Validation` which were created but undocumented, and `UI` which does not contain `Web` until `make-controller --web` creates it
+
+### Removed
+
+- Configuration keys that were declared but never read by any code: `auto_discovery`, `logging`, `stubs.path` and `validation.strict_mode`. None of them had any effect, so removing them changes no behaviour
+
+### Known limitations
+
+- `clean-arch:validate` inspects the class as written. A console command extending a project specific base class that itself extends `Illuminate\Console\Command` is not reported, and neither is a job extending an abstract base job that implements `ShouldQueue`. Following the chain would mean loading application code inside a validation command
+
+## [2.0.2] - 2026-04-04
+
+### Changed
+
+- Generated actions no longer receive a form request. `execute()` now takes an array, so the Application layer stops depending on `App\Infrastructure\Http\Requests`. Generated controllers pass `$request->validated()`
+- Generated actions no longer open a database transaction of their own, and `BaseAction::executeInTransaction()` is removed. Transaction control belongs to the caller
+
 ## [2.0.1] - 2026-03-31
 
 ### Fixed


### PR DESCRIPTION
## 2.1.0

Covers everything merged since `v2.0.2`: five fixes, three additions, the configuration keys that were removed, and one limitation stated rather than left to be discovered.

Version choice: no API was removed and `clean-arch:validate` changed only by dropping false positives, so this is a minor. The four configuration keys that go away (`auto_discovery`, `logging`, `stubs.path`, `validation.strict_mode`) were never read by any code, so removing them cannot break a project that set them.

The `Known limitations` section documents that `clean-arch:validate` inspects the class as written and does not follow inheritance chains. This is a deliberate scope decision, not an oversight, and users of the command should know it before they trust a clean run.

## 2.0.2

The tag exists but was never documented. Reconstructed from the single commit it contains, `f9d53c7`, and its diff.

That release changed generated actions to accept an array instead of a form request, which is what stops the Application layer depending on `App\Infrastructure\Http\Requests`, and removed `BaseAction::executeInTransaction()`. Both are changes to the shape of generated code, so they are recorded under `Changed` for the version that actually shipped them rather than being folded into 2.1.0.

## After merging

Tag `v2.1.0` on `main`.
