### PR TITLE
feat(validate)!: drop duplicate services directory rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-clean-architecture` will be documented in this file.
 
+## [Unreleased]
+
+### Removed
+
+- `no_duplicate_services_directory`, the rule that failed the validation when `app/Infrastructure/Services` existed. It checked a directory rather than a property of a class, so it has no equivalent in the rule set the package now generates for phparkitect, and keeping it would mean keeping a hand written check next to a delegated one. It came from a convention of this package, not from a principle of the architecture: a project that wants it back can assert `is_dir()` in three lines of its own. The `validation.rules` key is gone from `config/clean-architecture.php`, and a leftover key in a published config file is ignored
+
 ## [2.1.0] - 2026-08-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Clean Architecture Validation
   ✓ No Observers in Domain
   ✓ No Jobs in Infrastructure
   ✓ No Commands in Infrastructure
-  ✓ No duplicate Services directory
 
 No violations found.
 ```
@@ -263,7 +262,6 @@ Every rule run by `clean-arch:validate` can be turned off by name under `validat
         'no_observers_in_domain' => true,
         'no_jobs_in_infrastructure' => true,
         'no_commands_in_infrastructure' => true,
-        'no_duplicate_services_directory' => true,
     ],
 ],
 ```

--- a/config/clean-architecture.php
+++ b/config/clean-architecture.php
@@ -43,7 +43,6 @@ return [
             'no_observers_in_domain'                => true,
             'no_jobs_in_infrastructure'             => true,
             'no_commands_in_infrastructure'         => true,
-            'no_duplicate_services_directory'       => true,
         ],
     ],
 

--- a/src/Commands/ValidateArchitectureCommand.php
+++ b/src/Commands/ValidateArchitectureCommand.php
@@ -53,7 +53,6 @@ class ValidateArchitectureCommand extends Command
         $this->runFilePatternCheck('no_observers_in_domain', 'No Observers in Domain', $domain, '*Observer.php');
         $this->runClassCheck('no_jobs_in_infrastructure', 'No Jobs in Infrastructure', fn (): array => $this->checkQueuedJobViolations($infrastructure));
         $this->runClassCheck('no_commands_in_infrastructure', 'No Commands in Infrastructure', fn (): array => $this->checkConsoleCommandViolations($infrastructure));
-        $this->runDirectoryCheck('no_duplicate_services_directory', 'No duplicate Services directory', "{$infrastructure}/Services");
 
         $this->newLine();
 
@@ -257,25 +256,5 @@ class ValidateArchitectureCommand extends Command
         }
 
         return $violations;
-    }
-
-    protected function runDirectoryCheck(string $rule, string $label, string $directory): void
-    {
-        if ($this->skipsRule($rule, $label)) {
-            return;
-        }
-
-        if ($this->checkDirectoryNotExists($directory)) {
-            $this->violationCount++;
-            $this->line("  ✗ {$label}");
-            $this->line("    - {$directory} exists");
-        } else {
-            $this->line("  ✓ {$label}");
-        }
-    }
-
-    public function checkDirectoryNotExists(string $directory): bool
-    {
-        return $this->files->isDirectory(base_path($directory));
     }
 }

--- a/stubs/config.stub
+++ b/stubs/config.stub
@@ -43,7 +43,6 @@ return [
             'no_observers_in_domain' => true,
             'no_jobs_in_infrastructure' => true,
             'no_commands_in_infrastructure' => true,
-            'no_duplicate_services_directory' => true,
         ],
     ],
 

--- a/tests/Feature/CommandIntegrationTest.php
+++ b/tests/Feature/CommandIntegrationTest.php
@@ -173,15 +173,6 @@ describe('Command Integration', function () {
             ->assertExitCode(1);
     });
 
-    it('runs validate command and detects directory violations', function () {
-        // Create Infrastructure/Services directory (not allowed)
-        File::ensureDirectoryExists(app_path('Infrastructure/Services'));
-        File::put(app_path('Infrastructure/Services/.gitkeep'), '');
-
-        $this->artisan('clean-arch:validate')
-            ->assertExitCode(1);
-    });
-
     it('runs generate-package command', function () {
         $packagePath = base_path('packages/test-vendor/test-package');
 

--- a/tests/Unit/Commands/ValidateCommandTest.php
+++ b/tests/Unit/Commands/ValidateCommandTest.php
@@ -70,32 +70,6 @@ describe('ValidateArchitectureCommand', function () {
         expect($violations)->toBeArray()->toBeEmpty();
     });
 
-    it('detects duplicate services directory when it exists', function () {
-        $reflection = new ReflectionClass($this->command);
-        $method     = $reflection->getMethod('checkDirectoryNotExists');
-        $method->setAccessible(true);
-
-        $mockFilesystem = mock(Filesystem::class);
-        $mockFilesystem->shouldReceive('isDirectory')->andReturn(true);
-        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
-
-        $result = $method->invoke($this->command, 'app/Infrastructure/Services');
-        expect($result)->toBeTrue();
-    });
-
-    it('passes when services directory does not exist in infrastructure', function () {
-        $reflection = new ReflectionClass($this->command);
-        $method     = $reflection->getMethod('checkDirectoryNotExists');
-        $method->setAccessible(true);
-
-        $mockFilesystem = mock(Filesystem::class);
-        $mockFilesystem->shouldReceive('isDirectory')->andReturn(false);
-        $reflection->getProperty('files')->setValue($this->command, $mockFilesystem);
-
-        $result = $method->invoke($this->command, 'app/Infrastructure/Services');
-        expect($result)->toBeFalse();
-    });
-
     it('does not report a business class whose name merely contains Command', function () {
         writeAppFile(
             'app/Infrastructure/Http/Controllers/Api/CommandPaletteController.php',
@@ -211,7 +185,6 @@ describe('ValidateArchitectureCommand', function () {
         $method->setAccessible(true);
 
         expect($method->invoke($this->command, 'no_commands_in_infrastructure'))->toBeTrue();
-        expect($method->invoke($this->command, 'no_duplicate_services_directory'))->toBeTrue();
     });
 
     it('reads a disabled rule from the config', function () {


### PR DESCRIPTION
Removes `no_duplicate_services_directory`, the seventh rule of `clean-arch:validate`. Six of the seven rules have an equivalent in the phparkitect config generated by `clean-arch:make-arch-rules`. This one does not, and it is not going to get one.

## Why it goes

The rule failed the validation when `app/Infrastructure/Services` existed. It inspects a directory, not a property of a class, so no phparkitect expression covers it. Keeping it would mean keeping a hand written `is_dir()` check next to a delegated rule set, which is the exact shape of code this migration removes.

It also comes from a convention of this package rather than from a principle of the architecture. Nothing about clean architecture forbids that directory name. A project that wants the check back writes it in three lines.

## What changes for users

`clean-arch:validate` no longer prints the `No duplicate Services directory` line and no longer counts it as a violation. A project that has `app/Infrastructure/Services` and was failing on it now passes.

The key is gone from `config/clean-architecture.php` and from the published config stub. A leftover key in an already published config file is ignored, so nothing breaks on upgrade.

## Note on the plan behind this change

Removing the key from the two config files was expected to break the tests that cover the rule. It did not: `isRuleEnabled()` defaults to `true`, so an absent key leaves the rule enabled, and the config sync test only fires when the two files disagree. The behaviour changed only once the check itself was removed from the command. Worth knowing before assuming a missing key disables anything.

## Verification

216 tests, `vendor/bin/pint` clean, PHPStan level 6 clean. 61 lines removed, 6 added.
