### PR TITLE
feat(validate): warn about deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to `laravel-clean-architecture` will be documented in this file.
 
-## [Unreleased]
+## [2.2.0] - 2026-08-28
+
+### Added
+
+- `clean-arch:make-arch-rules` writes a `phparkitect.php` built from `directories`, `default_namespace` and `validation.rules`. The package neither depends on phparkitect nor runs it: install it in your own `require-dev` and run `vendor/bin/phparkitect check`. The generated rules follow inheritance chains, so a command extending a project base command is reported where `clean-arch:validate` misses it. The file opens with a `class_exists` guard, because the reflection based rules report nothing and exit 0 when autoloading does not resolve, which in CI reads as a pass. Pass `--force` to overwrite an existing file
+
+### Deprecated
+
+- `clean-arch:validate` prints a deprecation warning and will be removed in 3.0.0. It still runs every enabled rule and its exit codes are unchanged, so a pipeline that uses it keeps working until then. Replace it with `clean-arch:make-arch-rules` plus `vendor/bin/phparkitect check`, and use `vendor/bin/phparkitect generate-baseline` if the codebase already has violations to record
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ vendor/bin/phparkitect check
 php artisan clean-arch:validate
 ```
 
-`clean-arch:validate` still ships and still works. It reads the same `validation.rules` and needs no extra dependency, but it inspects each class as written and does not follow inheritance chains, so a command extending a base command is not reported. It is being replaced by the generated rules.
+`clean-arch:validate` is deprecated and will be removed in 3.0.0. It still runs every enabled rule with unchanged exit codes, and it reads the same `validation.rules`, but it inspects each class as written and does not follow inheritance chains, so a command extending a base command is not reported. Replace it with `clean-arch:make-arch-rules` plus `vendor/bin/phparkitect check`.
 
 ### 🛠️ Available commands
 

--- a/src/Commands/ValidateArchitectureCommand.php
+++ b/src/Commands/ValidateArchitectureCommand.php
@@ -39,6 +39,10 @@ class ValidateArchitectureCommand extends Command
 
     public function handle(): int
     {
+        $this->warn('clean-arch:validate is deprecated and will be removed in 3.0.0.');
+        $this->warn('Run clean-arch:make-arch-rules and check the generated phparkitect.php instead.');
+        $this->newLine();
+
         $this->info('Clean Architecture Validation');
         $this->info('=============================');
         $this->newLine();

--- a/tests/Unit/Commands/ValidateCommandTest.php
+++ b/tests/Unit/Commands/ValidateCommandTest.php
@@ -179,6 +179,33 @@ describe('ValidateArchitectureCommand', function () {
         expect($this->command->checkQueuedJobViolations('app/Infrastructure'))->toBe([$path]);
     });
 
+    it('warns that the command is deprecated and points at its replacement', function () {
+        $this->artisan('clean-arch:validate')
+            ->expectsOutputToContain('clean-arch:validate is deprecated')
+            ->expectsOutputToContain('clean-arch:make-arch-rules')
+            ->assertExitCode(0);
+    });
+
+    it('keeps reporting violations while deprecated', function () {
+        writeAppFile(
+            'app/Domain/Models/Product.php',
+            <<<'PHP'
+            <?php
+
+            namespace App\Domain\Models;
+
+            use App\Application\Services\ProductService;
+
+            class Product
+            {
+                public function __construct(private ProductService $service) {}
+            }
+            PHP
+        );
+
+        $this->artisan('clean-arch:validate')->assertExitCode(1);
+    });
+
     it('keeps every rule enabled when the config is not published', function () {
         $reflection = new ReflectionClass($this->command);
         $method     = $reflection->getMethod('isRuleEnabled');


### PR DESCRIPTION
Announces the removal of `clean-arch:validate` one minor before it happens, so nobody finds out by having a pipeline break.

## What changes

`handle()` opens with two warning lines naming the replacement:

```
clean-arch:validate is deprecated and will be removed in 3.0.0.
Run clean-arch:make-arch-rules and check the generated phparkitect.php instead.
```

Everything else is untouched. Every enabled rule still runs, exit codes are unchanged, and a pipeline calling the command keeps behaving exactly as before. Two tests cover it: one asserts the warning and the replacement name, one asserts a real violation still exits 1 while deprecated.

The README subsection on the command now says removal is coming in 3.0.0 rather than the vaguer "being replaced".

## CHANGELOG

The `Unreleased` heading becomes `2.2.0` and gains an `Added` entry for `clean-arch:make-arch-rules` and a `Deprecated` entry for this change, next to the `Removed` entry that was already there.

## One thing to decide before tagging

2.2.0 also carries the removal of `no_duplicate_services_directory`. Strictly that is a behaviour change in a minor release. It is a loosening, not a break: a project that had `app/Infrastructure/Services` was failing and now passes, so no pipeline that was green turns red. Shipping it as a minor is defensible on that basis, but if you would rather not, the alternative is to release the deprecation as 2.2.0 and hold the rule removal for 3.0.0, which is the release that already carries breaking changes.

## Verification

218 tests, `vendor/bin/pint` clean, PHPStan level 6 clean.
